### PR TITLE
Fix --log-level flag not working

### DIFF
--- a/internal/debutils/resolver.go
+++ b/internal/debutils/resolver.go
@@ -354,7 +354,9 @@ func compareDebianVersions(a, b string) (int, error) {
 	splitEpoch := func(ver string) (epoch int, rest string) {
 		parts := strings.SplitN(ver, ":", 2)
 		if len(parts) == 2 {
-			fmt.Sscanf(parts[0], "%d", &epoch)
+			if _, err := fmt.Sscanf(parts[0], "%d", &epoch); err != nil {
+				epoch = 0
+			}
 			rest = parts[1]
 		} else {
 			epoch = 0


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [*] The changes in the PR have been built and tested
- [*] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

The `--log-level` command line flag was not working due to logger initialization happening before flag parsing. The logger used `sync.Once` pattern which prevented re-initialization with the correct log level.

### Solution
- **Modified logger**: Use `zap.AtomicLevel` to enable dynamic log level changes without full re-initialization
- **Added `SetLogLevel()` function**: Allows changing log level on-the-fly using `atomicLevel.SetLevel()`
- **Used Cobra's `PersistentPreRun`**: Set log level after flag parsing but before command execution

### Changes
- `internal/utils/logger/logger.go`: Replace static level with `zap.AtomicLevel` and add dynamic level changing
- `main.go`: Add `PersistentPreRun` hook to apply `--log-level` flag after parsing

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->
### Testing
```bash
# Now works correctly - only shows ERROR level messages
./image-composer build --log-level error template.yml

# Also works with other levels
./image-composer build --log-level debug template.yml