### PR TITLE
Removed config show command

### DIFF
--- a/cmd/image-composer/main.go
+++ b/cmd/image-composer/main.go
@@ -76,7 +76,15 @@ func createRootCommand() *cobra.Command {
 		Short: "Image Composer Tool (ICT) for building Linux distributions",
 		Long: `Image Composer Tool (ICT) is a toolchain that enables building immutable
 Linux distributions using a simple toolchain from pre-built packages emanating
-from different Operating System Vendors (OSVs).`,
+from different Operating System Vendors (OSVs).
+
+The tool supports building custom images for:
+- EMT (Edge Microvisor Toolkit)
+- Azure Linux
+- Wind River eLxr
+
+Use 'image-composer --help' to see available commands.
+Use 'image-composer <command> --help' for more information about a command.`,
 	}
 
 	// Add global flags


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [X] The changes in the PR have been built and tested
- [] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->
Removed the image-composer config show subcommand to simplify the CLI interface.

# Remove `config show` command

## Summary
Removes the `image-composer config show` subcommand to simplify the CLI interface.

## Impact
- ✅ `image-composer config init` - Still works
- ❌ `image-composer config show` - No longer available
- Users can manually view config files instead of using the show command

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->
- [x] Verified `config init` functionality remains intact
- [x] Confirmed `config show` returns "unknown command" error
- [x] Updated help text reflects only available subcommands