### PR TITLE
Fix: Prevent mis-selection of source RPMs as download candidates

### DIFF
--- a/internal/ospackage/ospackage.go
+++ b/internal/ospackage/ospackage.go
@@ -4,6 +4,7 @@ package ospackage
 type PackageInfo struct {
 	Name     string   // e.g. "abseil-cpp"
 	Version  string   // e.g. "7.88.1-10+deb12u5"
+	Arch     string   // e.g. "x86_64", "noarch", "src"
 	URL      string   // download URL
 	Checksum string   // optional pre-known digest
 	Provides []string // capabilities this package provides (rpm:entry names)

--- a/internal/ospackage/rpmutils/download.go
+++ b/internal/ospackage/rpmutils/download.go
@@ -53,6 +53,9 @@ func MatchRequested(requests []string, all []ospackage.PackageInfo) ([]ospackage
 	for _, want := range requests {
 		var candidates []ospackage.PackageInfo
 		for _, pi := range all {
+			if pi.Arch == "src" {
+				continue
+			}
 			// 1) exact name match
 			if pi.Name == want || pi.Name == want+".rpm" {
 				candidates = append(candidates, pi)

--- a/internal/ospackage/rpmutils/resolver.go
+++ b/internal/ospackage/rpmutils/resolver.go
@@ -74,6 +74,9 @@ func ResolvePackageInfos(
 	requires := make(map[string][]string) // pkgName -> caps
 
 	for _, pi := range all {
+		if pi.Arch == "src" {
+			continue
+		}
 		byName[pi.Name] = pi
 		provides[pi.Name] = append(provides[pi.Name], pi.Name)
 		for _, cap := range pi.Provides {
@@ -247,6 +250,14 @@ func ParsePrimary(baseURL, gzHref string) ([]ospackage.PackageInfo, error) {
 				if err2 == nil {
 					if charData, ok := tok2.(xml.CharData); ok && curInfo != nil {
 						curInfo.Name = string(charData)
+					}
+				}
+			case "arch":
+				// Read the arch value
+				tok2, err2 := dec.Token()
+				if err2 == nil {
+					if charData, ok := tok2.(xml.CharData); ok {
+						curInfo.Arch = string(charData)
 					}
 				}
 			case "checksum":


### PR DESCRIPTION
- Added 'arch' field to PackageInfo.
- Stored arch info during primary XML parsing.
- Filtered source packages in MatchRequested and ResolvePackageInfos.

#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->
The `MatchRequested` and `ResolvePackageInfos` functions mis-selected source packages as candidates for fulfilling package dependencies. This led to errors in later stages, when the chroot environment attempted to set up with the required packages.
This issue does not happen in AZL builds because AZL `primary.xml` does not contain source package `<arch>src</arch>`.
In contrast, other distributions whose repository `primary.xml` files contain a mixture of arch (e.g., "x86_64", "noarch", and "src") encounter this problem.
This PR addresses the bug by adding a new arch field in the PackageInfo structure, which stores the arch info during the parsing of `primary.xml`.
This information will then be used for accurate candidate matching for download.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->
`go build ./cmd/image-composer`
`sudo ./image-composer build image-templates/emt3-x86_64-edge-raw.yml`
Observed the downloaded RPMs are correct (not .src.rpm)