### PR TITLE
[DOCS] codeowners extension for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-* @open-edge-platform/image-composer-maintain 
+* @open-edge-platform/image-composer-maintain
 
 # documentation content
-/docs @open-edge-platform/open-edge-platform-docs-write
-README.md @open-edge-platform/open-edge-platform-docs-write
+/docs       @open-edge-platform/image-composer-maintain  @open-edge-platform/open-edge-platform-docs-write
+README.md   @open-edge-platform/image-composer-maintain  @open-edge-platform/open-edge-platform-docs-write


### PR DESCRIPTION
#### Merge Checklist

- [x] The changes in the PR have been built and tested
- [x] Ready to merge

#### Description
Adjust CODEOWNERS, so that the docs team does not become the sole owner of the docs folder. Instead, both the maintainer and docs groups here should be able to approve and merge documentation PRs.
