### PR TITLE
Enable auto install host dependencies per osv

### DIFF
--- a/internal/provider/emt/emt.go
+++ b/internal/provider/emt/emt.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-edge-platform/image-composer/internal/ospackage/rpmutils"
 	"github.com/open-edge-platform/image-composer/internal/provider"
 	"github.com/open-edge-platform/image-composer/internal/utils/logger"
+	"github.com/open-edge-platform/image-composer/internal/utils/shell"
 )
 
 const (
@@ -75,12 +76,15 @@ func (p *Emt) Init(dist, arch string) error {
 }
 
 func (p *Emt) PreProcess(template *config.ImageTemplate) error {
-	err := p.downloadImagePkgs(template)
-	if err != nil {
+	if err := p.installHostDependency(); err != nil {
+		return fmt.Errorf("failed to install host dependencies: %v", err)
+	}
+
+	if err := p.downloadImagePkgs(template); err != nil {
 		return fmt.Errorf("failed to download image packages: %v", err)
 	}
-	err = chroot.InitChrootEnv(config.TargetOs, config.TargetDist, config.TargetArch)
-	if err != nil {
+
+	if err := chroot.InitChrootEnv(config.TargetOs, config.TargetDist, config.TargetArch); err != nil {
 		return fmt.Errorf("failed to initialize chroot environment: %v", err)
 	}
 	return nil
@@ -111,6 +115,37 @@ func (p *Emt) PostProcess(template *config.ImageTemplate, err error) error {
 		return fmt.Errorf("failed to cleanup chroot environment: %v", err)
 	}
 	return err
+}
+
+func (p *Emt) installHostDependency() error {
+	log := logger.Logger()
+	var depedencyInfo = map[string]string{
+		"rpm":      "rpm",        // For the chroot env build RPM pkg installation
+		"mkfs.fat": "dosfstools", // For the FAT32 boot partition creation
+		"xorriso":  "xorriso",    // For ISO image creation
+	}
+	hostPkgManager, err := chroot.GetHostOsPkgManager()
+	if err != nil {
+		return fmt.Errorf("failed to get host package manager: %w", err)
+	}
+
+	for cmd, pkg := range depedencyInfo {
+		cmdExist, err := shell.IsCommandExist(cmd, "")
+		if err != nil {
+			return fmt.Errorf("failed to check command %s existence: %w", cmd, err)
+		}
+		if !cmdExist {
+			cmdStr := fmt.Sprintf("%s install -y %s", hostPkgManager, pkg)
+			_, err := shell.ExecCmdWithStream(cmdStr, true, "", nil)
+			if err != nil {
+				return fmt.Errorf("failed to install host dependency %s: %w", pkg, err)
+			}
+			log.Debugf("Installed host dependency: %s", pkg)
+		} else {
+			log.Debugf("Host dependency %s is already installed", pkg)
+		}
+	}
+	return nil
 }
 
 func (p *Emt) downloadImagePkgs(template *config.ImageTemplate) error {


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

This PR is to enable auto install host dependencies per target OS.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->

2025-08-04T11:17:03.872+0800    INFO    chroot/chrootbuild.go:131       Detected OS info: Ubuntu 22.04 x86_64
2025-08-04T11:17:03.874+0800    DEBUG   emt/emt.go:145  Host dependency rpm is already installed
2025-08-04T11:17:03.875+0800    DEBUG   emt/emt.go:145  Host dependency dosfstools is already installed
2025-08-04T11:17:03.877+0800    DEBUG   emt/emt.go:145  Host dependency xorriso is already installed


2025-08-04T11:13:38.015+0800    INFO    chroot/chrootbuild.go:131       Detected OS info: Ubuntu 22.04 x86_64
2025-08-04T11:13:38.016+0800    DEBUG   elxr/elxr.go:135        Host dependency dosfstools is already installed
2025-08-04T11:13:38.017+0800    DEBUG   elxr/elxr.go:135        Host dependency xorriso is already installed
2025-08-04T11:13:38.019+0800    DEBUG   shell/shell.go:241      Exec: [sudo /usr/bin/apt install -y systemd-ukify]
2025-08-04T11:13:38.031+0800    DEBUG   shell/shell.go:335      WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
2025-08-04T11:13:38.126+0800    DEBUG   shell/shell.go:324      Reading package lists...
2025-08-04T11:13:38.499+0800    DEBUG   shell/shell.go:324      Building dependency tree...
2025-08-04T11:13:38.501+0800    DEBUG   shell/shell.go:324      Reading state information...
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324      The following packages were automatically installed and are no longer required:
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        apg apport-symptoms aptdaemon-data avahi-utils cups-pk-helper
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        desktop-file-utils fdisk gdisk gir1.2-accountsservice-1.0 gir1.2-adw-1
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gir1.2-atspi-2.0 gir1.2-ayatanaappindicator3-0.1 gir1.2-dbusmenu-glib-0.4
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gir1.2-dee-1.0 gir1.2-gck-2 gir1.2-gcr-4 gir1.2-gdesktopenums-3.0
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gir1.2-gdm-1.0 gir1.2-geoclue-2.0 gir1.2-gnomebg-4.0
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gir1.2-gnomebluetooth-3.0 gir1.2-gnomedesktop-3.0 gir1.2-gnomedesktop-4.0
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gir1.2-goa-1.0 gir1.2-graphene-1.0 gir1.2-gst-plugins-base-1.0
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gir1.2-gstreamer-1.0 gir1.2-gtk-4.0 gir1.2-gtk-vnc-2.0 gir1.2-gtksource-4
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gir1.2-gudev-1.0 gir1.2-gweather-4.0 gir1.2-handy-1 gir1.2-ibus-1.0
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gir1.2-javascriptcoregtk-4.0 gir1.2-javascriptcoregtk-6.0
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gir1.2-libvirt-glib-1.0 gir1.2-mutter-14 gir1.2-nm-1.0 gir1.2-nma4-1.0
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gir1.2-notify-0.7 gir1.2-packagekitglib-1.0 gir1.2-polkit-1.0 gir1.2-rb-3.0
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gir1.2-rsvg-2.0 gir1.2-snapd-1 gir1.2-soup-2.4 gir1.2-soup-3.0
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gir1.2-spiceclientglib-2.0 gir1.2-spiceclientgtk-3.0 gir1.2-totem-1.0
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gir1.2-totemplparser-1.0 gir1.2-udisks-2.0 gir1.2-unity-7.0
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gir1.2-upowerglib-1.0 gir1.2-vte-2.91 gir1.2-webkit-6.0 gir1.2-webkit2-4.0
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gir1.2-wnck-3.0 gkbd-capplet gnome-control-center-faces
2025-08-04T11:13:38.799+0800    DEBUG   shell/shell.go:324        gnome-online-accounts gnome-session-bin gnome-session-common
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        gnome-shell-common gnome-startup-applications gnome-terminal-data
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        gstreamer1.0-pipewire gstreamer1.0-pulseaudio heif-gdk-pixbuf
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        heif-thumbnailer hplip-data ibus-data ibus-gtk4 libatasmart4
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        libblockdev-crypto2 libblockdev-loop2 libblockdev-part-err2
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        libblockdev-part2 libblockdev-swap2 libblockdev-utils2 libblockdev2
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        libcolord-gtk4-1t64 libde265-0 libdmapsharing-4.0-3t64 libgnome-autoar-0-0
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        libgnome-bluetooth-ui-3.0-13 libgnome-rr-4-2t64 libgnomekbd-common
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        libgnomekbd8 libgoa-backend-1.0-2 libgpod-common libgpod4t64 libgsound0t64
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        libgssdp-1.2-0 libgupnp-1.2-1 libgupnp-av-1.0-3 libgupnp-dlna-2.0-4
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        libheif-plugin-aomdec libheif-plugin-aomenc libheif-plugin-libde265 libheif1
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        libhpmud0 liblirc-client0t64 libmalcontent-0-0 libmozjs-115-0t64
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        libmtp-common libmtp-runtime libmtp9t64 libplist-2.0-4 libportal-gtk3-1
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        libportal1 librest-1.0-0 librygel-core-2.6-2 librygel-db-2.6-2
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        librygel-renderer-2.6-2 librygel-server-2.6-2 libsane-hpaio libsgutils2-2
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        libsmbclient0 libsnapd-glib1 libudisks2-0 libvolume-key1
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        libwhoopsie-preferences0 libwnck-3-0 libwnck-3-common libxklavier16 libxres1
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        mobile-broadband-provider-info network-manager-gnome policykit-1-gnome
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        power-profiles-daemon printer-driver-hpcups printer-driver-postscript-hp
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        python3-brlapi python3-cairo python3-cups python3-cupshelpers
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        python3-dateutil python3-debconf python3-debian python3-defer
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        python3-freetype python3-louis python3-mako python3-reportlab
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        python3-rlpycairo python3-speechd python3-systemd python3-xdg rygel
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        switcheroo-control system-config-printer-udev
2025-08-04T11:13:38.800+0800    DEBUG   shell/shell.go:324        ubuntu-advantage-desktop-daemon unattended-upgrades update-notifier-common
2025-08-04T11:13:38.801+0800    DEBUG   shell/shell.go:324        whoopsie-preferences xbrlapi xwayland
2025-08-04T11:13:38.801+0800    DEBUG   shell/shell.go:324      Use 'sudo apt autoremove' to remove them.
2025-08-04T11:13:38.802+0800    DEBUG   shell/shell.go:324      The following additional packages will be installed:
2025-08-04T11:13:38.802+0800    DEBUG   shell/shell.go:324        libnss-mymachines libnss-systemd libpam-systemd libsystemd-shared
2025-08-04T11:13:38.803+0800    DEBUG   shell/shell.go:324        libsystemd0 libudev-dev libudev1 python3-pefile systemd systemd-container
2025-08-04T11:13:38.803+0800    DEBUG   shell/shell.go:324        systemd-dev systemd-oomd systemd-resolved systemd-sysv systemd-timesyncd
2025-08-04T11:13:38.803+0800    DEBUG   shell/shell.go:324        udev
2025-08-04T11:13:38.804+0800    DEBUG   shell/shell.go:324      Suggested packages:
2025-08-04T11:13:38.804+0800    DEBUG   shell/shell.go:324        systemd-homed systemd-userdbd systemd-boot libqrencode4
2025-08-04T11:13:38.804+0800    DEBUG   shell/shell.go:324      Recommended packages:
2025-08-04T11:13:38.804+0800    DEBUG   shell/shell.go:324        networkd-dispatcher
2025-08-04T11:13:38.906+0800    DEBUG   shell/shell.go:324      The following NEW packages will be installed:
2025-08-04T11:13:38.906+0800    DEBUG   shell/shell.go:324        python3-pefile systemd-ukify
2025-08-04T11:13:38.907+0800    DEBUG   shell/shell.go:324      The following packages will be upgraded:
2025-08-04T11:13:38.908+0800    DEBUG   shell/shell.go:324        libnss-mymachines libnss-systemd libpam-systemd libsystemd-shared
2025-08-04T11:13:38.908+0800    DEBUG   shell/shell.go:324        libsystemd0 libudev-dev libudev1 systemd systemd-container systemd-dev
2025-08-04T11:13:38.908+0800    DEBUG   shell/shell.go:324        systemd-oomd systemd-resolved systemd-sysv systemd-timesyncd udev
2025-08-04T11:13:38.950+0800    DEBUG   shell/shell.go:324      15 upgraded, 2 newly installed, 0 to remove and 1284 not upgraded.
2025-08-04T11:13:39.882+0800    DEBUG   shell/shell.go:324      Need to get 9,602 kB of archives.
2025-08-04T11:13:39.882+0800    DEBUG   shell/shell.go:324      After this operation, 581 kB of additional disk space will be used.
2025-08-04T11:13:39.882+0800    DEBUG   shell/shell.go:324      Get:1 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libnss-systemd amd64 255.4-1ubuntu8.10 [159 kB]
2025-08-04T11:13:40.612+0800    DEBUG   shell/shell.go:324      Get:2 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 systemd-dev all 255.4-1ubuntu8.10 [105 kB]
2025-08-04T11:13:41.160+0800    DEBUG   shell/shell.go:324      Get:3 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libudev-dev amd64 255.4-1ubuntu8.10 [22.0 kB]
2025-08-04T11:13:41.708+0800    DEBUG   shell/shell.go:324      Get:4 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 systemd-timesyncd amd64 255.4-1ubuntu8.10 [35.3 kB]
2025-08-04T11:13:42.257+0800    DEBUG   shell/shell.go:324      Get:5 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 systemd-resolved amd64 255.4-1ubuntu8.10 [296 kB]
2025-08-04T11:13:43.140+0800    DEBUG   shell/shell.go:324      Get:6 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 systemd-oomd amd64 255.4-1ubuntu8.10 [39.2 kB]
2025-08-04T11:13:43.680+0800    DEBUG   shell/shell.go:324      Get:7 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libnss-mymachines amd64 255.4-1ubuntu8.10 [153 kB]
2025-08-04T11:13:44.222+0800    DEBUG   shell/shell.go:324      Get:8 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 systemd-container amd64 255.4-1ubuntu8.10 [417 kB]
2025-08-04T11:13:44.796+0800    DEBUG   shell/shell.go:324      Get:9 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libsystemd-shared amd64 255.4-1ubuntu8.10 [2,074 kB]
2025-08-04T11:13:46.325+0800    DEBUG   shell/shell.go:324      Get:10 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libsystemd0 amd64 255.4-1ubuntu8.10 [434 kB]
2025-08-04T11:13:47.060+0800    DEBUG   shell/shell.go:324      Get:11 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 systemd-sysv amd64 255.4-1ubuntu8.10 [11.9 kB]
2025-08-04T11:13:47.403+0800    DEBUG   shell/shell.go:324      Get:12 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libpam-systemd amd64 255.4-1ubuntu8.10 [235 kB]
2025-08-04T11:13:47.942+0800    DEBUG   shell/shell.go:324      Get:13 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 systemd amd64 255.4-1ubuntu8.10 [3,475 kB]
2025-08-04T11:13:49.471+0800    DEBUG   shell/shell.go:324      Get:14 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 udev amd64 255.4-1ubuntu8.10 [1,873 kB]
2025-08-04T11:13:50.207+0800    DEBUG   shell/shell.go:324      Get:15 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libudev1 amd64 255.4-1ubuntu8.10 [176 kB]
2025-08-04T11:13:50.746+0800    DEBUG   shell/shell.go:324      Get:16 http://archive.ubuntu.com/ubuntu noble/universe amd64 python3-pefile all 2023.2.7-3 [66.5 kB]
2025-08-04T11:13:51.284+0800    DEBUG   shell/shell.go:324      Get:17 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 systemd-ukify all 255.4-1ubuntu8.10 [29.8 kB]
2025-08-04T11:13:52.028+0800    DEBUG   shell/shell.go:324      Fetched 9,602 kB in 12s (768 kB/s)
(Reading database ... 296524 files and directories currently installed.) database ...
2025-08-04T11:13:52.191+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../0-libnss-systemd_255.4-1ubuntu8.10_amd64.deb ...
2025-08-04T11:13:52.205+0800    DEBUG   shell/shell.go:324      Unpacking libnss-systemd:amd64 (255.4-1ubuntu8.10) over (255.4-1ubuntu8.8) ...
2025-08-04T11:13:52.278+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../1-systemd-dev_255.4-1ubuntu8.10_all.deb ...
2025-08-04T11:13:52.282+0800    DEBUG   shell/shell.go:324      Unpacking systemd-dev (255.4-1ubuntu8.10) over (255.4-1ubuntu8.8) ...
2025-08-04T11:13:52.340+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../2-libudev-dev_255.4-1ubuntu8.10_amd64.deb ...
2025-08-04T11:13:52.344+0800    DEBUG   shell/shell.go:324      Unpacking libudev-dev:amd64 (255.4-1ubuntu8.10) over (255.4-1ubuntu8.8) ...
2025-08-04T11:13:52.401+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../3-systemd-timesyncd_255.4-1ubuntu8.10_amd64.deb ...
2025-08-04T11:13:52.408+0800    DEBUG   shell/shell.go:324      Unpacking systemd-timesyncd (255.4-1ubuntu8.10) over (255.4-1ubuntu8.8) ...
2025-08-04T11:13:52.466+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../4-systemd-resolved_255.4-1ubuntu8.10_amd64.deb ...
2025-08-04T11:13:52.472+0800    DEBUG   shell/shell.go:324      Unpacking systemd-resolved (255.4-1ubuntu8.10) over (255.4-1ubuntu8.8) ...
2025-08-04T11:13:52.532+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../5-systemd-oomd_255.4-1ubuntu8.10_amd64.deb ...
2025-08-04T11:13:52.539+0800    DEBUG   shell/shell.go:324      Unpacking systemd-oomd (255.4-1ubuntu8.10) over (255.4-1ubuntu8.8) ...
2025-08-04T11:13:52.596+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../6-libnss-mymachines_255.4-1ubuntu8.10_amd64.deb ...
2025-08-04T11:13:52.603+0800    DEBUG   shell/shell.go:324      Unpacking libnss-mymachines:amd64 (255.4-1ubuntu8.10) over (255.4-1ubuntu8.8) ...
2025-08-04T11:13:52.676+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../7-systemd-container_255.4-1ubuntu8.10_amd64.deb ...
2025-08-04T11:13:52.683+0800    DEBUG   shell/shell.go:324      Unpacking systemd-container (255.4-1ubuntu8.10) over (255.4-1ubuntu8.8) ...
2025-08-04T11:13:52.752+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../8-libsystemd-shared_255.4-1ubuntu8.10_amd64.deb ...
2025-08-04T11:13:52.756+0800    DEBUG   shell/shell.go:324      Unpacking libsystemd-shared:amd64 (255.4-1ubuntu8.10) over (255.4-1ubuntu8.8) ...
2025-08-04T11:13:52.836+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../9-libsystemd0_255.4-1ubuntu8.10_amd64.deb ...
2025-08-04T11:13:52.840+0800    DEBUG   shell/shell.go:324      Unpacking libsystemd0:amd64 (255.4-1ubuntu8.10) over (255.4-1ubuntu8.8) ...
2025-08-04T11:13:52.910+0800    DEBUG   shell/shell.go:324      Setting up libsystemd0:amd64 (255.4-1ubuntu8.10) ...
(Reading database ... 296524 files and directories currently installed.) database ...
2025-08-04T11:13:53.073+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../systemd-sysv_255.4-1ubuntu8.10_amd64.deb ...
2025-08-04T11:13:53.078+0800    DEBUG   shell/shell.go:324      Unpacking systemd-sysv (255.4-1ubuntu8.10) over (255.4-1ubuntu8.8) ...
2025-08-04T11:13:53.127+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../libpam-systemd_255.4-1ubuntu8.10_amd64.deb ...
2025-08-04T11:13:53.134+0800    DEBUG   shell/shell.go:324      Unpacking libpam-systemd:amd64 (255.4-1ubuntu8.10) over (255.4-1ubuntu8.8) ...
2025-08-04T11:13:53.187+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../systemd_255.4-1ubuntu8.10_amd64.deb ...
2025-08-04T11:13:53.209+0800    DEBUG   shell/shell.go:324      Unpacking systemd (255.4-1ubuntu8.10) over (255.4-1ubuntu8.8) ...
2025-08-04T11:13:53.476+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../udev_255.4-1ubuntu8.10_amd64.deb ...
2025-08-04T11:13:53.499+0800    DEBUG   shell/shell.go:324      Unpacking udev (255.4-1ubuntu8.10) over (255.4-1ubuntu8.8) ...
2025-08-04T11:13:53.640+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../libudev1_255.4-1ubuntu8.10_amd64.deb ...
2025-08-04T11:13:53.644+0800    DEBUG   shell/shell.go:324      Unpacking libudev1:amd64 (255.4-1ubuntu8.10) over (255.4-1ubuntu8.8) ...
2025-08-04T11:13:53.709+0800    DEBUG   shell/shell.go:324      Setting up libudev1:amd64 (255.4-1ubuntu8.10) ...
2025-08-04T11:13:53.758+0800    DEBUG   shell/shell.go:324      Selecting previously unselected package python3-pefile.
(Reading database ... 296524 files and directories currently installed.) database ...
2025-08-04T11:13:53.873+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../python3-pefile_2023.2.7-3_all.deb ...
2025-08-04T11:13:53.874+0800    DEBUG   shell/shell.go:324      Unpacking python3-pefile (2023.2.7-3) ...
2025-08-04T11:13:53.903+0800    DEBUG   shell/shell.go:324      Selecting previously unselected package systemd-ukify.
2025-08-04T11:13:53.921+0800    DEBUG   shell/shell.go:324      Preparing to unpack .../systemd-ukify_255.4-1ubuntu8.10_all.deb ...
2025-08-04T11:13:53.923+0800    DEBUG   shell/shell.go:324      Unpacking systemd-ukify (255.4-1ubuntu8.10) ...
2025-08-04T11:13:53.992+0800    DEBUG   shell/shell.go:324      Setting up systemd-dev (255.4-1ubuntu8.10) ...
2025-08-04T11:13:53.996+0800    DEBUG   shell/shell.go:324      Setting up libsystemd-shared:amd64 (255.4-1ubuntu8.10) ...
2025-08-04T11:13:54.000+0800    DEBUG   shell/shell.go:324      Setting up libudev-dev:amd64 (255.4-1ubuntu8.10) ...
2025-08-04T11:13:54.004+0800    DEBUG   shell/shell.go:324      Setting up python3-pefile (2023.2.7-3) ...
2025-08-04T11:13:54.167+0800    DEBUG   shell/shell.go:324      Setting up systemd (255.4-1ubuntu8.10) ...
2025-08-04T11:13:54.644+0800    DEBUG   shell/shell.go:324      Setting up systemd-timesyncd (255.4-1ubuntu8.10) ...
2025-08-04T11:13:55.146+0800    DEBUG   shell/shell.go:324      Setting up udev (255.4-1ubuntu8.10) ...
2025-08-04T11:13:55.922+0800    DEBUG   shell/shell.go:324      Setting up systemd-container (255.4-1ubuntu8.10) ...
2025-08-04T11:13:56.352+0800    DEBUG   shell/shell.go:324      Setting up systemd-oomd (255.4-1ubuntu8.10) ...
2025-08-04T11:13:57.293+0800    DEBUG   shell/shell.go:324      Setting up systemd-resolved (255.4-1ubuntu8.10) ...
2025-08-04T11:13:57.832+0800    DEBUG   shell/shell.go:324      Setting up systemd-sysv (255.4-1ubuntu8.10) ...
2025-08-04T11:13:57.892+0800    DEBUG   shell/shell.go:324      Setting up systemd-ukify (255.4-1ubuntu8.10) ...
2025-08-04T11:13:57.896+0800    DEBUG   shell/shell.go:324      Setting up libnss-systemd:amd64 (255.4-1ubuntu8.10) ...
2025-08-04T11:13:57.901+0800    DEBUG   shell/shell.go:324      Setting up libnss-mymachines:amd64 (255.4-1ubuntu8.10) ...
2025-08-04T11:13:57.906+0800    DEBUG   shell/shell.go:324      Setting up libpam-systemd:amd64 (255.4-1ubuntu8.10) ...
2025-08-04T11:13:58.072+0800    DEBUG   shell/shell.go:324      Processing triggers for libc-bin (2.39-0ubuntu8.4) ...
2025-08-04T11:13:58.109+0800    DEBUG   shell/shell.go:324      Processing triggers for man-db (2.10.2-1) ...
2025-08-04T11:13:58.445+0800    DEBUG   shell/shell.go:324      Processing triggers for dbus (1.12.20-2ubuntu4.1) ...
2025-08-04T11:13:58.459+0800    DEBUG   shell/shell.go:324      Processing triggers for initramfs-tools (0.140ubuntu13.4) ...
2025-08-04T11:13:58.485+0800    DEBUG   shell/shell.go:324      update-initramfs: Generating /boot/initrd.img-6.8.0-65-generic
2025-08-04T11:14:05.972+0800    DEBUG   shell/shell.go:324      I: The initramfs will attempt to resume from /dev/dm-1
2025-08-04T11:14:05.972+0800    DEBUG   shell/shell.go:324      I: (/dev/mapper/vgubuntu-swap_1)
2025-08-04T11:14:05.972+0800    DEBUG   shell/shell.go:324      I: Set the RESUME variable to override this.
2025-08-04T11:14:48.118+0800    DEBUG   elxr/elxr.go:133        Installed host dependency: systemd-ukify
2025-08-04T11:14:48.120+0800    DEBUG   elxr/elxr.go:135        Host dependency mmdebstrap is already installed
