### PR TITLE
fix broken unit test

### DIFF
--- a/internal/ospackage/debutils/download_test.go
+++ b/internal/ospackage/debutils/download_test.go
@@ -131,7 +131,7 @@ func TestUserPackages(t *testing.T) {
 				}
 				Architecture = "amd64"
 			},
-			expectError: false, // The function skips invalid repos and continues
+			expectError: true,
 		},
 	}
 

--- a/internal/ospackage/pkgfetcher/pkgfetcher_test.go
+++ b/internal/ospackage/pkgfetcher/pkgfetcher_test.go
@@ -115,11 +115,10 @@ func TestFetchPackages_HTTPErrors(t *testing.T) {
 		server.URL + "/success.rpm",
 	}
 
-	// This should not return an error even if some downloads fail
-	// The function logs errors but continues processing
+	// This should return an error due to HTTP failures
 	err = FetchPackages(urls, tempDir, 1)
-	if err != nil {
-		t.Errorf("FetchPackages should not return error for HTTP failures, got: %v", err)
+	if err == nil {
+		t.Errorf("FetchPackages should return error for HTTP failures, got nil")
 	}
 
 	// Check that successful download still happened
@@ -318,10 +317,10 @@ func TestFetchPackages_NetworkError(t *testing.T) {
 		"http://non-existent-server-12345.example.com/package.rpm",
 	}
 
-	// This should not return an error - errors are logged but not returned
+	// This should return an error due to network failure
 	err = FetchPackages(urls, tempDir, 1)
-	if err != nil {
-		t.Errorf("FetchPackages should not return error for network failures, got: %v", err)
+	if err == nil {
+		t.Errorf("FetchPackages should return error for network failures, got nil")
 	}
 }
 


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [/] The changes in the PR have been built and tested
- [/] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->
fix broken unit test

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->

root@staripin-mobl:/data/image-composer# cat coverage_total.txt
## Test Coverage Report

**Overall Coverage:** 52.9%
**Threshold:** 52.8% (applies to overall coverage only)
**Status:** PASSED

**Note:** Directory PASS/FAIL indicates test results only, not coverage.
**Note:** Coverage threshold applies to overall repository coverage only.

| Directory                           | Coverage | Result   |
|-------------------------------------|----------|----------|
| cmd/os-image-composer               |     48.9% | PASS     |
| internal/chroot                     |      0.5% | PASS     |
| internal/chroot/chrootbuild         |     33.3% | PASS     |
| internal/chroot/deb                 |     69.8% | PASS     |
| internal/chroot/rpm                 |     72.7% | PASS     |
| internal/config                     |     65.5% | PASS     |
| internal/config/manifest            |     83.1% | PASS     |
| internal/config/schema              |      N/A | NO-TESTS |
| internal/config/validate            |     96.0% | PASS     |
| internal/config/version             |      N/A | NO-TESTS |
| internal/image/imageboot            |     36.5% | PASS     |
| internal/image/imageconvert         |     92.6% | PASS     |
| internal/image/imagedisc            |     55.9% | PASS     |
| internal/image/imageos              |     18.7% | PASS     |
| internal/image/imagesecure          |     92.4% | PASS     |
| internal/image/imagesign            |     85.4% | PASS     |
| internal/image/initrdmaker          |     77.6% | PASS     |
| internal/image/isomaker             |      6.9% | PASS     |
| internal/image/rawmaker             |     88.5% | PASS     |
| internal/ospackage                  |      N/A | NO-TESTS |
| internal/ospackage/debutils         |     59.3% | PASS     |
| internal/ospackage/pkgfetcher       |     90.7% | PASS     |
| internal/ospackage/pkgsorter        |     96.9% | PASS     |
| internal/ospackage/resolvertest     |     84.6% | PASS     |
| internal/ospackage/rpmutils         |     73.7% | PASS     |
| internal/provider                   |    100.0% | PASS     |
| internal/provider/azl               |     57.0% | PASS     |
| internal/provider/elxr              |     42.3% | PASS     |
| internal/provider/emt               |     54.5% | PASS     |
| internal/utils/compression          |    100.0% | PASS     |
| internal/utils/file                 |     47.8% | PASS     |
| internal/utils/logger               |      N/A | NO-TESTS |
| internal/utils/mount                |     90.0% | PASS     |
| internal/utils/network              |    100.0% | PASS     |
| internal/utils/security             |     83.1% | PASS     |
| internal/utils/shell                |     53.1% | PASS     |
| internal/utils/slice                |     50.0% | PASS     |
| internal/utils/system               |     98.6% | PASS     |