### PR TITLE
Change SHA256 to SHA384 for secure boot signing

### DIFF
--- a/docs/tutorial/configure-secure-boot.md
+++ b/docs/tutorial/configure-secure-boot.md
@@ -17,16 +17,17 @@ Create a directory for your keys and generate the required certificates:
 mkdir -p /data/secureboot/keys
 cd /data/secureboot/keys
 
-# Generate private key and certificate using RSA 3072-bit with SHA-256 (recommended for secure boot)
-openssl req -new -x509 -newkey rsa:3072 -sha256 -keyout DB.key -out DB.crt -days 3650 -nodes -subj "/CN=ICT Secure Boot Key/"
+# Generate private key and certificate using RSA 3072-bit with SHA-384
+openssl req -new -x509 -newkey rsa:3072 -sha384 -keyout DB.key -out DB.crt -days 3650 -nodes -subj "/CN=ICT Secure Boot Key/"
 
 # Convert certificate to DER format (required by UEFI)
 openssl x509 -outform DER -in DB.crt -out DB.cer
 ```
 
-**Security Note:** The above commands use RSA 3072-bit keys with SHA-256 hashing, which is the recommended configuration for UEFI Secure Boot.
+NOTE: The signing keypair strength should align with the crypto implementation supported by the UEFI Secure boot implementation on a specific system. The recommendation is to test the support for `RSA3072SHA384` before moving to `RSA2048SHA256`.
 
 **What you'll have:**
+
 - `DB.key` - Private key (keep secure)
 - `DB.crt` - Certificate in PEM format
 - `DB.cer` - Certificate in DER format (for UEFI)


### PR DESCRIPTION
o Generally, the BIOS supports RSA3072 with SHA384 for secure boot
  signing, so, updating the documentation to reflect that.

#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [] The changes in the PR have been built and tested
- [] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->