### PR TITLE
Display all image artifacts after build completion

### DIFF
--- a/internal/image/isomaker/isomaker.go
+++ b/internal/image/isomaker/isomaker.go
@@ -107,6 +107,8 @@ func (isoMaker *IsoMaker) BuildIsoImage() (err error) {
 		// Don't fail the build if SBOM copy fails, just log warning
 	}
 
+	log.Infof("ISO image build completed successfully: %s", isoFilePath)
+
 	return nil
 }
 

--- a/internal/image/rawmaker/rawmaker.go
+++ b/internal/image/rawmaker/rawmaker.go
@@ -161,7 +161,9 @@ func (rawMaker *RawMaker) BuildRawImage() error {
 		return fmt.Errorf("failed to rename image file: %w", err)
 	}
 
-	// Image conversion
+	log.Infof("Raw image build completed successfully: %s", finalImagePath)
+
+	// Image conversion (may compress/remove original file)
 	if err := rawMaker.ImageConvert.ConvertImageFile(finalImagePath, rawMaker.template); err != nil {
 		rawMaker.cleanupImageFileOnError(finalImagePath)
 		return fmt.Errorf("failed to convert image file: %w", err)
@@ -173,6 +175,5 @@ func (rawMaker *RawMaker) BuildRawImage() error {
 		// Don't fail the build if SBOM copy fails, just log warning
 	}
 
-	log.Infof("Raw image build completed successfully: %s", finalImagePath)
 	return nil
 }

--- a/internal/provider/azl/azl.go
+++ b/internal/provider/azl/azl.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-edge-platform/os-image-composer/internal/image/rawmaker"
 	"github.com/open-edge-platform/os-image-composer/internal/ospackage/rpmutils"
 	"github.com/open-edge-platform/os-image-composer/internal/provider"
+	"github.com/open-edge-platform/os-image-composer/internal/utils/display"
 	"github.com/open-edge-platform/os-image-composer/internal/utils/logger"
 	"github.com/open-edge-platform/os-image-composer/internal/utils/shell"
 	"github.com/open-edge-platform/os-image-composer/internal/utils/system"
@@ -126,7 +127,22 @@ func (p *AzureLinux) buildRawImage(template *config.ImageTemplate) error {
 		return fmt.Errorf("failed to initialize raw maker: %w", err)
 	}
 
-	return rawMaker.BuildRawImage()
+	if err := rawMaker.BuildRawImage(); err != nil {
+		return err
+	}
+
+	// Display summary after build completes (loop device detached, files accessible)
+	// Construct the actual image build directory path (on host, not in chroot)
+	globalWorkDir, err := config.WorkDir()
+	if err != nil {
+		return fmt.Errorf("failed to get work directory: %w", err)
+	}
+	providerId := system.GetProviderId(template.Target.OS, template.Target.Dist, template.Target.Arch)
+	imageBuildDir := filepath.Join(globalWorkDir, providerId, "imagebuild", template.GetSystemConfigName())
+
+	displayImageArtifacts(imageBuildDir, "RAW")
+
+	return nil
 }
 
 func (p *AzureLinux) buildInitrdImage(template *config.ImageTemplate) error {
@@ -162,7 +178,22 @@ func (p *AzureLinux) buildIsoImage(template *config.ImageTemplate) error {
 		return fmt.Errorf("failed to initialize iso maker: %w", err)
 	}
 
-	return isoMaker.BuildIsoImage()
+	if err := isoMaker.BuildIsoImage(); err != nil {
+		return err
+	}
+
+	// Display summary after build completes
+	// Construct the actual image build directory path (on host, not in chroot)
+	globalWorkDir, err := config.WorkDir()
+	if err != nil {
+		return fmt.Errorf("failed to get work directory: %w", err)
+	}
+	providerId := system.GetProviderId(template.Target.OS, template.Target.Dist, template.Target.Arch)
+	imageBuildDir := filepath.Join(globalWorkDir, providerId, "imagebuild", template.GetSystemConfigName())
+
+	displayImageArtifacts(imageBuildDir, "ISO")
+
+	return nil
 }
 
 func (p *AzureLinux) PostProcess(template *config.ImageTemplate, err error) error {
@@ -259,4 +290,9 @@ func loadRepoConfigFromYAML(dist, arch string) (rpmutils.RepoConfig, error) {
 
 	log.Infof("Loaded repo config from YAML for %s: %+v", OsName, cfg)
 	return cfg, nil
+}
+
+// displayImageArtifacts displays all image artifacts in the build directory
+func displayImageArtifacts(imageBuildDir, imageType string) {
+	display.PrintImageDirectorySummary(imageBuildDir, imageType)
 }

--- a/internal/utils/display/display.go
+++ b/internal/utils/display/display.go
@@ -1,0 +1,81 @@
+package display
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/open-edge-platform/os-image-composer/internal/utils/logger"
+)
+
+// PrintImageDirectorySummary displays all image artifacts in a directory
+// This is called after image build completes to show all generated files
+func PrintImageDirectorySummary(imageBuildDir, imageType string) {
+	log := logger.Logger()
+
+	log.Infof("Checking for image artifacts in: %s", imageBuildDir)
+
+	// List all files in the directory (excluding SBOM)
+	files, err := os.ReadDir(imageBuildDir)
+	if err != nil {
+		log.Warnf("Unable to read image build directory %s: %v", imageBuildDir, err)
+		return
+	}
+
+	log.Infof("Found %d total entries in directory", len(files))
+
+	// Collect all files (including SBOM)
+	var imageFiles []string
+	for _, file := range files {
+		name := file.Name()
+		log.Infof("Checking file: %s (isDir=%v)", name, file.IsDir())
+
+		if file.IsDir() {
+			continue
+		}
+		imageFiles = append(imageFiles, name)
+	}
+
+	log.Infof("Found %d artifacts after filtering", len(imageFiles))
+
+	if len(imageFiles) == 0 {
+		log.Warn("No artifacts found in build directory")
+		return
+	}
+
+	// Print highlighted box with success message
+	log.Info("")
+	log.Info("╔════════════════════════════════════════════════════════════════════════════╗")
+	log.Info("║                    ✓ IMAGE CREATED SUCCESSFULLY                            ║")
+	log.Info("╚════════════════════════════════════════════════════════════════════════════╝")
+	log.Info("")
+
+	// Print image type
+	log.Infof("  Image Type:   %s", imageType)
+	log.Info("")
+	log.Info("  Generated Artifacts (including SBOM):")
+
+	// Print each artifact with size
+	for _, filename := range imageFiles {
+		fullPath := filepath.Join(imageBuildDir, filename)
+		fileInfo, err := os.Stat(fullPath)
+		var sizeStr string
+		if err == nil {
+			sizeMB := float64(fileInfo.Size()) / (1024 * 1024)
+			if sizeMB > 1024 {
+				sizeStr = fmt.Sprintf("%.2f GB", sizeMB/1024)
+			} else {
+				sizeStr = fmt.Sprintf("%.2f MB", sizeMB)
+			}
+		} else {
+			sizeStr = "unknown"
+		}
+
+		log.Infof("    • %s (%s)", filename, sizeStr)
+		log.Infof("      %s", fullPath)
+		log.Info("")
+	}
+
+	log.Info("════════════════════════════════════════════════════════════════════════════")
+	log.Info("")
+}


### PR DESCRIPTION
#### Merge Checklist
**All** boxes should be checked before merging the PR

- [X] The changes in the PR have been built and tested
- [X] Ready to merge

#### Description
This PR improves the visibility of generated image artifacts by adding a comprehensive display utility that shows all created files after a successful build.

**Problem:**
- Final image path was difficult to locate among cleanup logs

**Solution:**
- Created new display utility (\`internal/utils/display/display.go\`)
- Shows ALL generated artifacts (RAW, VHDX, compressed files, SBOM)
- Displays artifact names, sizes (GB/MB formatted), and full paths
- Clear, highlighted banner format
- Runs at provider level after build completes and loop devices are detached
- Changed default log level to info to reduce the noise

**Benefits:**
- Better visibility of all generated artifacts
- Clear output easy to find in logs
- File sizes after compression/conversion
- Consistent across all providers
- Includes SBOM files

#### Any Newly Introduced Dependencies
No new 3rd party dependencies introduced

#### How Has This Been Tested?

- Built and tested with ELXR RAW image builds using \`elxr12-x86_64-minimal-raw.yml\`and \`elxr12-x86_64-minimal-iso.yml\`
- Verified all artifact types are displayed (raw.gz, vhdx, SBOM)
- Confirmed file sizes are accurate and properly formatted
- Validated path construction works correctly across providers
- Tested that display occurs after loop device detachment

**Example Output:**

Before changes: ./build/os-image-composer   build --cache-dir ./test2cache/ image-templates/elxr12-x86_64-minimal-raw.yml
<img width="464" height="420" alt="image" src="https://github.com/user-attachments/assets/8cef0fff-98dc-4c73-be64-5462761e1fa2" />


After Changes: ./build/os-image-composer   build --cache-dir ./test2cache/ image-templates/elxr12-x86_64-minimal-raw.yml

<img width="772" height="316" alt="image" src="https://github.com/user-attachments/assets/f4ddc081-393f-44b9-94b3-14ad8300140f" />

After changes: ./build/os-image-composer   build --cache-dir ./test2cache/ image-templates/elxr12-x86_64-minimal-iso.yml

<img width="770" height="262" alt="image" src="https://github.com/user-attachments/assets/ee30022e-e452-4c0d-b21b-e59ee5ab7e8a" />

