### PR TITLE
Add kernel command line parameters for console and i915 force probe

### DIFF
--- a/image-templates/elxr12-x86_64-dlstreamer.yml
+++ b/image-templates/elxr12-x86_64-dlstreamer.yml
@@ -79,6 +79,7 @@ systemConfig:
 
   kernel:
     version: "6.12"
+    cmdline: "console=ttyS0,115200 console=tty0 loglevel=7 i915.force_probe=*"
     packages:
       - linux-image-6.12-intel
       - linux-headers-6.12-intel


### PR DESCRIPTION
Configure kernel cmdline to enable serial console output and force i915 driver probing for better hardware compatibility.

#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->