### PR TITLE
lock kernel version to ecg 6.12 for all dlstreamer images

### DIFF
--- a/image-templates/azl3-x86_64-dlstreamer.yml
+++ b/image-templates/azl3-x86_64-dlstreamer.yml
@@ -16,7 +16,7 @@ packageRepositories:
     pkey: "https://yum.repos.intel.com/edgeai/GPG-PUB-KEY-INTEL-DLS.gpg" # Uncomment and replace in real config
 
   - codename: "edge-base"
-    url: "https://files-rs.edgeorchestration.intel.com/files-edge-orch/microvisor/rpm/3.0/"
+    url: "https://files-rs.edgeorchestration.intel.com/files-edge-orch/microvisor/rpms/3.0/base"
     pkey: "https://raw.githubusercontent.com/open-edge-platform/edge-microvisor-toolkit/refs/heads/3.0/SPECS/edge-repos/INTEL-RPM-GPG-KEY" # Uncomment and replace in real config
 
   - codename: "OpenVINO"
@@ -76,7 +76,10 @@ systemConfig:
     - opencv
     - intel-dlstreamer
     - openvino-2025.2.0
+    - linux-firmware-i915
 
   kernel:
     version: "6.12"
-    cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
+    cmdline: "console=ttyS0,115200 console=tty0 loglevel=7 i915.force_probe=*"
+    packages:
+      - kernel-drivers-gpu-6.12.55

--- a/image-templates/emt3-x86_64-dlstreamer.yml
+++ b/image-templates/emt3-x86_64-dlstreamer.yml
@@ -78,4 +78,6 @@ systemConfig:
   # Kernel Configuration
   kernel:
     version: "6.12"
-    cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
+    cmdline: "console=ttyS0,115200 console=tty0 loglevel=7 i915.force_probe=*"
+    packages:
+      - kernel-drivers-gpu-6.12.55

--- a/image-templates/ubuntu24-x86_64-dlstreamer.yml
+++ b/image-templates/ubuntu24-x86_64-dlstreamer.yml
@@ -66,9 +66,11 @@ systemConfig:
 
   packages:
     - intel-dlstreamer
+    - linux-firmware
 
   kernel:
-    version: "6.8" # Ubuntu 24.04 LTS default kernel version
+    version: "6.12"
+    cmdline: "console=ttyS0,115200 console=tty0 loglevel=7 i915.force_probe=*"
     packages:
-      - linux-image-generic
-      - linux-headers-generic
+      - linux-image-6.12-intel
+      - linux-headers-6.12-intel


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [/] The changes in the PR have been built and tested
- [/] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->
lock dlstreamer images kernel version to 6.12

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->
<img width="879" height="314" alt="Screenshot 2025-12-10 140740" src="https://github.com/user-attachments/assets/6cf2b513-a5e3-4dfc-afd6-eec32c75ebd1" />
<img width="935" height="423" alt="Screenshot 2025-12-10 135716" src="https://github.com/user-attachments/assets/6db5bc2c-453e-4f9a-9e22-6fd6b7fb416c" />
<img width="602" height="341" alt="Screenshot 2025-12-10 135303" src="https://github.com/user-attachments/assets/c7da8eb8-7c06-4d48-b935-2c6e77ee210f" />
