### PR TITLE
Fix regression defect - config file loading and nil provider panic

### DIFF
--- a/cmd/os-image-composer/build.go
+++ b/cmd/os-image-composer/build.go
@@ -99,8 +99,10 @@ func executeBuild(cmd *cobra.Command, args []string) error {
 
 post:
 
-	if err := p.PostProcess(template, buildErr); err != nil {
-		return fmt.Errorf("post-processing failed: %v", err)
+	if p != nil {
+		if err := p.PostProcess(template, buildErr); err != nil {
+			return fmt.Errorf("post-processing failed: %v", err)
+		}
 	}
 
 	if buildErr == nil {

--- a/cmd/os-image-composer/main.go
+++ b/cmd/os-image-composer/main.go
@@ -56,9 +56,9 @@ func initConfig() {
 	if logFilePath != "" {
 		globalConfig.Logging.File = logFilePath
 	}
-	globalConfig = config.Global()
-	globalConfig.Logging.Level = logLevel
-	config.SetGlobal(globalConfig)
+	if logLevel != "" {
+		globalConfig.Logging.Level = logLevel
+	}
 
 	// Set global config singleton
 	config.SetGlobal(globalConfig)


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [X] The changes in the PR have been built and tested
- [X] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

- main.go: Remove erroneous 'globalConfig = config.Global()' that was
  overwriting the config loaded from file with defaults. This caused
  the tool to ignore config_dir from /etc/os-image-composer/config.yml
  and use './config' instead, breaking installed Debian package usage.
  
- build.go: Add nil check for provider before calling PostProcess()
  to prevent panic when provider initialization fails.

Fixes regression introduced in commit 2d5b5ed.

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->