### PR TITLE
Remove unused --dotfile CLI flag from build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,6 @@ Flags:
 - `--cache-dir, -d`: Package cache directory (overrides the configuration file)
 - `--work-dir`: Working directory for builds (overrides the configuration file)
 - `--verbose, -v`: Enable verbose output
-- `--dotfile, -f`: Generate dependency graph as a dot file
 - `--config`: Path to the configuration file
 - `--log-level`: Log level (debug, info, warn, and error)
 - `--log-file`: Override the log file path defined in the configuration

--- a/cmd/os-image-composer/build.go
+++ b/cmd/os-image-composer/build.go
@@ -19,7 +19,6 @@ var (
 	workers  int    = -1 // -1 means use config file value
 	cacheDir string = "" // Empty means use config file value
 	workDir  string = "" // Empty means use config file value
-	dotFile  string = "" // Generate a dot file for the dependency graph
 )
 
 // createBuildCommand creates the build subcommand
@@ -41,7 +40,6 @@ The template file must be in YAML format following the image template schema.`,
 		"Package cache directory")
 	buildCmd.Flags().StringVar(&workDir, "work-dir", "",
 		"Working directory for builds")
-	buildCmd.Flags().StringVarP(&dotFile, "dotfile", "f", "", "Generate a dot file for the dependency graph")
 
 	return buildCmd
 }

--- a/cmd/os-image-composer/build_test.go
+++ b/cmd/os-image-composer/build_test.go
@@ -20,7 +20,6 @@ func resetBuildFlags() {
 	workers = -1
 	cacheDir = ""
 	workDir = ""
-	dotFile = ""
 }
 
 // createTestTemplate creates a minimal valid template file for testing
@@ -105,7 +104,6 @@ func TestCreateBuildCommand(t *testing.T) {
 			{name: "workers", shorthand: "w", shouldExist: true},
 			{name: "cache-dir", shorthand: "d", shouldExist: true},
 			{name: "work-dir", shorthand: "", shouldExist: true},
-			{name: "dotfile", shorthand: "f", shouldExist: true},
 		}
 
 		for _, expected := range expectedFlags {
@@ -526,9 +524,6 @@ func TestBuildFlags_DefaultValues(t *testing.T) {
 	if verbose != false {
 		t.Errorf("verbose should default to false, got %v", verbose)
 	}
-	if dotFile != "" {
-		t.Errorf("dotFile should default to empty, got %q", dotFile)
-	}
 }
 
 // TestBuildCommand_FlagParsing tests that flags are correctly parsed
@@ -558,19 +553,6 @@ func TestBuildCommand_FlagParsing(t *testing.T) {
 				}
 			},
 		},
-		{
-			name: "DotFileFlag",
-			args: []string{"--dotfile", "deps.dot", "template.yml"},
-			validate: func(t *testing.T) {
-				if err := cmd.ParseFlags([]string{"--dotfile", "deps.dot"}); err != nil {
-					t.Fatalf("failed to parse flags: %v", err)
-				}
-				val, _ := cmd.Flags().GetString("dotfile")
-				if val != "deps.dot" {
-					t.Errorf("expected dotfile='deps.dot', got %q", val)
-				}
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -593,7 +575,6 @@ func TestBuildCommand_HelpText(t *testing.T) {
 		"--workers",
 		"--cache-dir",
 		"--work-dir",
-		"--dotfile",
 	}
 
 	for _, expected := range expectedInHelp {

--- a/docs/architecture/os-image-composer-build-process.md
+++ b/docs/architecture/os-image-composer-build-process.md
@@ -356,9 +356,6 @@ sudo -E os-image-composer build \
 
 # Enable verbose logging for debugging
 sudo -E os-image-composer build --verbose my-template.yml
-
-# Generate dependency graph visualization
-sudo -E os-image-composer build --dotfile deps.dot my-template.yml
 ```
 
 ## Common Build Patterns
@@ -518,7 +515,6 @@ Error: Package conflict: package-a requires version 1.0, but version 2.0 is alre
 - Review your package list for conflicting requirements
 - Check if you're mixing packages from incompatible repositories
 - Use specific package versions if needed
-- Review dependency resolution with `--dotfile` to visualize conflicts
 
 **Problem: Chroot environment corruption**
 

--- a/docs/architecture/os-image-composer-cli-specification.md
+++ b/docs/architecture/os-image-composer-cli-specification.md
@@ -143,7 +143,6 @@ os-image-composer build [flags] TEMPLATE_FILE
 | `--cache-dir, -d DIR` | Package cache directory (overrides config). Proper caching significantly improves build times. |
 | `--work-dir DIR` | Working directory for builds (overrides config). This directory is where images are constructed before being finalized. |
 | `--verbose, -v` | Enable verbose output (equivalent to --log-level debug). Displays detailed information about each step of the build process. |
-| `--dotfile, -f FILE` | Generate a dot file for the dependency graph. Useful for visualizing package dependencies. |
 
 **Example:**
 
@@ -156,9 +155,6 @@ sudo -E os-image-composer build --workers 16 --cache-dir /tmp/cache my-image-tem
 
 # Build with verbose output
 sudo -E os-image-composer build --verbose my-image-template.yml
-
-# Build and generate dependency graph
-sudo -E os-image-composer build --dotfile deps.dot my-image-template.yml
 ```
 
 **Note:** The build command typically requires sudo privileges for operations like creating loopback devices and mounting filesystems.

--- a/docs/index.md
+++ b/docs/index.md
@@ -220,7 +220,6 @@ Flags:
 - `--cache-dir, -d`: Package cache directory (overrides the configuration file)
 - `--work-dir`: Working directory for builds (overrides the configuration file)
 - `--verbose, -v`: Enable verbose output
-- `--dotfile, -f`: Generate dependency graph as a dot file
 - `--config`: Path to the configuration file
 - `--log-level`: Log level (debug, info, warn, and error)
 


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [X] The changes in the PR have been built and tested
- [X] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->
The \`--dotfile\` (\`-f\`) flag was defined but not actually used in the build process.

## Changes
- Removed \`dotFile\` variable and flag registration from \`build.go\`
- Removed related tests from \`build_test.go\`
- Updated documentation (README.md, docs/index.md, CLI spec, build process docs)
- 
Note: There is still a dot file generated (chrootpkgs.dot) in the chroot package cache directory (workspace/<provider>/chrootbuild/pkgcache/chrootpkgs.dot), which shows the dependency graph for the chroot environment packages only 

## Testing
- All existing tests pass
- Code compiles successfully
<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->