### PR TITLE
Fix/dot file naming bug

### DIFF
--- a/internal/ospackage/ospackage.go
+++ b/internal/ospackage/ospackage.go
@@ -2,20 +2,21 @@ package ospackage
 
 // PackageInfo holds everything you need to fetch + verify one artifact.
 type PackageInfo struct {
-	Name        string // e.g. file name "abseil-cpp.rpm"
-	Type        string // e.g. "rpm", "deb", "apk"
-	Description string // e.g. "Abseil C++ Common Libraries"
-	Origin      string // e.g. "Intel", the vendor or supplier of the package
-	License     string // e.g. "Apache-2.0"
-	Version     string // e.g. "7.88.1-10+deb12u5"
-	Arch        string // e.g. "x86_64", "noarch", "src"
-	URL         string // download URL
-	Checksums   []Checksum
-	Provides    []string // capabilities this package provides (rpm:entry names)
-	Requires    []string // capabilities this package requires
-	RequiresVer []string // version constraints for the required capabilities
-	Files       []string // list of files in this package (rpm:files)
-	PkgName     string   // name of the package
+	Name             string // e.g. file name "abseil-cpp.rpm"
+	Type             string // e.g. "rpm", "deb", "apk"
+	Description      string // e.g. "Abseil C++ Common Libraries"
+	Origin           string // e.g. "Intel", the vendor or supplier of the package
+	License          string // e.g. "Apache-2.0"
+	Version          string // e.g. "7.88.1-10+deb12u5"
+	Arch             string // e.g. "x86_64", "noarch", "src"
+	URL              string // download URL
+	Checksums        []Checksum
+	Provides         []string // capabilities this package provides (rpm:entry names)
+	Requires         []string // capabilities this package requires
+	RequiresVer      []string // version constraints for the required capabilities
+	RequiresPkgNames []string // canonical package names of dependencies (extracted from Requires)
+	Files            []string // list of files in this package (rpm:files)
+	PkgName          string   // name of the package
 }
 
 // Checksum holds the algorithm and value of a checksum.

--- a/internal/ospackage/rpmutils/resolver.go
+++ b/internal/ospackage/rpmutils/resolver.go
@@ -192,18 +192,16 @@ func GenerateDot(pkgs []ospackage.PackageInfo, file string, pkgSources map[strin
 		// Note: Multiple package versions (e.g., glibc-2.38 and glibc-2.35) will both produce "glibc"
 		// This causes duplicate node declarations in the DOT file, which is valid - GraphViz merges them.
 		// For visualization purposes, we only care about package relationships, not specific versions.
-		cleanName := extractBasePackageNameFromFile(pkg.Name)
+		cleanName := pkg.PkgName
 		if _, err := fmt.Fprintf(writer, "  \"%s\";\n", cleanName); err != nil {
 			return fmt.Errorf("writing DOT node for %s: %w", cleanName, err)
 		}
-		for _, dep := range pkg.Requires {
+		for _, dep := range pkg.RequiresPkgNames {
 			if dep == "" {
 				continue
 			}
 			// Extract clean dependency name for edges (handles capabilities and package requirements)
 			cleanDep := extractBaseRequirement(dep)
-			// Also trim package filenames (e.g., "glibc-2.38-16.azl3.x86_64.rpm" -> "glibc")
-			cleanDep = extractBasePackageNameFromFile(cleanDep)
 			edgeKey := cleanName + "|" + cleanDep
 			if edgesWritten[edgeKey] {
 				continue
@@ -427,6 +425,8 @@ func ParseRepositoryMetadata(baseURL, gzHref string, packageFilter []string) ([]
 								} else if section == "requires" {
 									// Store the base name in Requires
 									curInfo.Requires = append(curInfo.Requires, name)
+									// Store the base name in RequiresPkgNames
+									curInfo.RequiresPkgNames = append(curInfo.RequiresPkgNames, name)
 
 									// Store version constraint with package name prefix in RequiresVer
 									if version != "" || release != "" || epoch != "" || flags != "" {
@@ -721,9 +721,11 @@ func ResolveDependencies(requested []ospackage.PackageInfo, all []ospackage.Pack
 	// Clear required fields for all and requested
 	for i := range all {
 		all[i].Requires = nil
+		all[i].RequiresPkgNames = nil
 	}
 	for i := range requested {
 		requested[i].Requires = nil
+		requested[i].RequiresPkgNames = nil
 	}
 
 	neededSet := make(map[string]struct{})
@@ -791,6 +793,16 @@ func ResolveDependencies(requested []ospackage.PackageInfo, all []ospackage.Pack
 				// Append to parent's Requires field even if already resolved
 				if resultPkg, exists := resultMap[cur.Name]; exists {
 					resultPkg.Requires = append(resultPkg.Requires, filename)
+					// Store canonical package name from the already-resolved dependency
+					if depPkg, depExists := resultMap[filename]; depExists {
+						if depPkg.PkgName != "" {
+							resultPkg.RequiresPkgNames = append(resultPkg.RequiresPkgNames, depPkg.PkgName)
+						} else {
+							// Extract canonical name from filename if PkgName not available
+							canonicalName := extractBasePackageNameFromFile(filename)
+							resultPkg.RequiresPkgNames = append(resultPkg.RequiresPkgNames, canonicalName)
+						}
+					}
 				}
 
 				continue
@@ -812,6 +824,14 @@ func ResolveDependencies(requested []ospackage.PackageInfo, all []ospackage.Pack
 				// Update the parent's Requires field with the chosen candidate's name
 				if resultPkg, exists := resultMap[cur.Name]; exists {
 					resultPkg.Requires = append(resultPkg.Requires, chosenCandidate.Name)
+					// Store canonical package name of the chosen candidate
+					if chosenCandidate.PkgName != "" {
+						resultPkg.RequiresPkgNames = append(resultPkg.RequiresPkgNames, chosenCandidate.PkgName)
+					} else {
+						// Extract canonical name from filename if PkgName not available
+						canonicalName := extractBasePackageNameFromFile(chosenCandidate.Name)
+						resultPkg.RequiresPkgNames = append(resultPkg.RequiresPkgNames, canonicalName)
+					}
 				}
 
 				// Add chosen candidate to the queue for further processing

--- a/internal/ospackage/rpmutils/resolver_test.go
+++ b/internal/ospackage/rpmutils/resolver_test.go
@@ -132,16 +132,22 @@ func TestGenerateDot(t *testing.T) {
 			name: "simple package with dependencies",
 			packages: []ospackage.PackageInfo{
 				{
-					Name:     "bash",
-					Requires: []string{"glibc", "ncurses"},
+					Name:             "bash",
+					PkgName:          "bash",
+					Requires:         []string{"glibc", "ncurses"},
+					RequiresPkgNames: []string{"glibc", "ncurses"},
 				},
 				{
-					Name:     "glibc",
-					Requires: []string{},
+					Name:             "glibc",
+					PkgName:          "glibc",
+					Requires:         []string{},
+					RequiresPkgNames: []string{},
 				},
 				{
-					Name:     "ncurses",
-					Requires: []string{"glibc"},
+					Name:             "ncurses",
+					PkgName:          "ncurses",
+					Requires:         []string{"glibc"},
+					RequiresPkgNames: []string{"glibc"},
 				},
 			},
 			filename:    filepath.Join(tmpDir, "simple.dot"),
@@ -157,8 +163,10 @@ func TestGenerateDot(t *testing.T) {
 			name: "package with no dependencies",
 			packages: []ospackage.PackageInfo{
 				{
-					Name:     "standalone",
-					Requires: []string{},
+					Name:             "standalone",
+					PkgName:          "standalone",
+					Requires:         []string{},
+					RequiresPkgNames: []string{},
 				},
 			},
 			filename:    filepath.Join(tmpDir, "standalone.dot"),
@@ -168,12 +176,16 @@ func TestGenerateDot(t *testing.T) {
 			name: "packages with special characters in names",
 			packages: []ospackage.PackageInfo{
 				{
-					Name:     "package-with-dashes",
-					Requires: []string{"lib.so.1"},
+					Name:             "package-with-dashes",
+					PkgName:          "package-with-dashes",
+					Requires:         []string{"lib.so.1"},
+					RequiresPkgNames: []string{"lib.so.1"},
 				},
 				{
-					Name:     "lib.so.1",
-					Requires: []string{},
+					Name:             "lib.so.1",
+					PkgName:          "lib.so.1",
+					Requires:         []string{},
+					RequiresPkgNames: []string{},
 				},
 			},
 			filename:    filepath.Join(tmpDir, "special_chars.dot"),
@@ -182,8 +194,8 @@ func TestGenerateDot(t *testing.T) {
 		{
 			name: "with package source colors",
 			packages: []ospackage.PackageInfo{
-				{Name: "kernel", Requires: []string{}},
-				{Name: "boot", Requires: []string{}},
+				{Name: "kernel", PkgName: "kernel", Requires: []string{}, RequiresPkgNames: []string{}},
+				{Name: "boot", PkgName: "boot", Requires: []string{}, RequiresPkgNames: []string{}},
 			},
 			filename: filepath.Join(tmpDir, "sources.dot"),
 			pkgSources: map[string]config.PackageSource{
@@ -196,16 +208,22 @@ func TestGenerateDot(t *testing.T) {
 			name: "duplicate dependencies should be deduplicated",
 			packages: []ospackage.PackageInfo{
 				{
-					Name:     "libstdc++",
-					Requires: []string{"glibc", "glibc", "glibc", "libgcc", "libgcc"},
+					Name:             "libstdc++",
+					PkgName:          "libstdc++",
+					Requires:         []string{"glibc", "glibc", "glibc", "libgcc", "libgcc"},
+					RequiresPkgNames: []string{"glibc", "glibc", "glibc", "libgcc", "libgcc"},
 				},
 				{
-					Name:     "glibc",
-					Requires: []string{},
+					Name:             "glibc",
+					PkgName:          "glibc",
+					Requires:         []string{},
+					RequiresPkgNames: []string{},
 				},
 				{
-					Name:     "libgcc",
-					Requires: []string{"glibc"},
+					Name:             "libgcc",
+					PkgName:          "libgcc",
+					Requires:         []string{"glibc"},
+					RequiresPkgNames: []string{"glibc"},
 				},
 			},
 			filename:    filepath.Join(tmpDir, "dedup.dot"),


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [ ] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->
libpcre2-16-0 and libpcre2-32-0 was processed incorrectly previously, there were recognized as libpcre2 due to a word processing logic error. The method is flawed and this commit tries to minimize the use of the extractBasePackageNameFromFile to extract the canonical name, only use it as a fallback method when the canonical name isn't available. 

RequiresPkgNames is introduced as a new item in the PackageInfo struct, this item contains canonical name of required package. It is only used for GenerateDot for now, but could be useful for future feature implementation.
Before:
<img width="843" height="456" alt="before" src="https://github.com/user-attachments/assets/937886ed-a8e0-48ac-bb6e-e6633458c4c2" />
After:
<img width="795" height="520" alt="after" src="https://github.com/user-attachments/assets/4130ac78-3304-4835-b932-8e28af1ecdd1" />
#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->