### PR TITLE
fix iso installer

### DIFF
--- a/config/general/isolinux/attendedinstaller
+++ b/config/general/isolinux/attendedinstaller
@@ -2,13 +2,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+set -o pipefail
+
 ISO_ROOT=/cdrom
 CONFIG_ROOT=$ISO_ROOT/config
 CACHE_REPO=$ISO_ROOT/cache-repo
+INSTALLER_LOG=/tmp/live-installer-attended.log
 
 # Mounting the ISO root for the installer.
 mkdir -p $ISO_ROOT
-LABEL=OIC_CDROM
+LABEL=ICT_CDROM
 
 function retry {
     local retry=0
@@ -51,8 +54,9 @@ stty -echo
 # Disable kernel messages on the current terminal
 dmesg -D
 
-live-installer --config $TEMPLATE_DUMP_YAML --repo $CACHE_REPO --attended
-installerExitCode=$?
+echo "Saving installer debug log to $INSTALLER_LOG"
+live-installer --config $TEMPLATE_DUMP_YAML --repo $CACHE_REPO --attended --log-level debug 2>&1 | tee -a "$INSTALLER_LOG"
+installerExitCode=${PIPESTATUS[0]}
 
 # Consume any buffered stdin to prevent it from being passed to any future programs,
 # as it may contain sensitive data
@@ -70,5 +74,6 @@ dmesg -E
 if [ $installerExitCode -eq 0 ]; then
     reboot
 else
+    echo "Installer failed. Debug log saved at $INSTALLER_LOG"
     /bin/bash
 fi

--- a/config/general/isolinux/attendedinstaller
+++ b/config/general/isolinux/attendedinstaller
@@ -2,6 +2,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# Set pipefail to catch errors in pipelines (e.g., live-installer | tee).
+# Note: -e is not set because the retry loop intentionally allows command failures.
+# Note: -u is not set to allow optional variable expansion; critical vars are pre-checked.
 set -o pipefail
 
 ISO_ROOT=/cdrom
@@ -55,7 +58,8 @@ stty -echo
 dmesg -D
 
 echo "Saving installer debug log to $INSTALLER_LOG"
-live-installer --config $TEMPLATE_DUMP_YAML --repo $CACHE_REPO --attended --log-level debug 2>&1 | tee -a "$INSTALLER_LOG"
+# Overwrite log (not append) to produce a clean log for each run
+live-installer --config $TEMPLATE_DUMP_YAML --repo $CACHE_REPO --attended --log-level debug 2>&1 | tee "$INSTALLER_LOG"
 installerExitCode=${PIPESTATUS[0]}
 
 # Consume any buffered stdin to prevent it from being passed to any future programs,

--- a/config/general/isolinux/unattendedinstaller
+++ b/config/general/isolinux/unattendedinstaller
@@ -8,7 +8,7 @@ CACHE_REPO=$ISO_ROOT/cache-repo
 
 # Mounting the ISO root for the installer.
 mkdir -p $ISO_ROOT
-LABEL=OIC_CDROM
+LABEL=ICT_CDROM
 
 function retry {
     local retry=0

--- a/config/osv/azure-linux/azl3/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
+++ b/config/osv/azure-linux/azl3/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
@@ -26,6 +26,7 @@ systemConfig:
     - ca-certificates
     - cronie-anacron
     - logrotate
+    - gptfdisk
     - shadow-utils
     - util-linux
 

--- a/config/osv/debian/debian13/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
+++ b/config/osv/debian/debian13/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
@@ -48,12 +48,13 @@ systemConfig:
     - systemd-boot
     - grub-pc-bin
     - grub-efi-amd64-bin
+    - gdisk
 
   additionalFiles:
     - local: ../additionalfiles/dhcp.network
       final: /etc/systemd/network/dhcp.network
-    - local: ../additionalfiles/ubuntu-noble.list
-      final: /etc/apt/sources.list.d/ubuntu-noble.list
+    - local: ../additionalfiles/debian-trixie.list
+      final: /etc/apt/sources.list.d/debian-trixie.list
     - local: ../additionalfiles/getty@.service
       final: /usr/lib/systemd/system/getty@.service
     - local: ../additionalfiles/serial-getty@.service

--- a/config/osv/edge-microvisor-toolkit/emt3/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
+++ b/config/osv/edge-microvisor-toolkit/emt3/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
@@ -26,6 +26,7 @@ systemConfig:
     - ca-certificates
     - cronie-anacron
     - logrotate
+    - gptfdisk
     - shadow-utils
     - util-linux
 

--- a/config/osv/redhat-compatible-distro/el10/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
+++ b/config/osv/redhat-compatible-distro/el10/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
@@ -26,6 +26,7 @@ systemConfig:
     - ca-certificates
     - cronie-anacron
     - logrotate
+    - gptfdisk
     - shadow-utils
     - util-linux
 

--- a/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
+++ b/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
@@ -41,6 +41,7 @@ systemConfig:
     - systemd-boot
     - grub-pc-bin
     - grub-efi-amd64-bin
+    - gdisk
 
 
   additionalFiles:

--- a/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-iso-x86_64.yml
+++ b/config/osv/ubuntu/ubuntu24/imageconfigs/defaultconfigs/default-iso-x86_64.yml
@@ -59,5 +59,6 @@ systemConfig: # Required
 
   kernel:
     name: kernel
+    cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
      - linux-image-generic-hwe-24.04

--- a/config/osv/ubuntu/ubuntu26/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
+++ b/config/osv/ubuntu/ubuntu26/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
@@ -41,6 +41,7 @@ systemConfig:
     - systemd-boot
     - grub-pc-bin
     - grub-efi-amd64-bin
+    - gdisk
 
 
   additionalFiles:

--- a/config/osv/wind-river-elxr/elxr12/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
+++ b/config/osv/wind-river-elxr/elxr12/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
@@ -42,6 +42,7 @@ systemConfig:
     - grub2
     - grub-pc-bin
     - grub-efi-amd64-bin
+    - gdisk
 
   additionalFiles:
     - local: ../additionalfiles/dhcp.network

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -185,18 +185,18 @@ type KernelConfig struct {
 
 // PartitionInfo holds information about a partition in the disk layout
 type PartitionInfo struct {
-	Name         string   `yaml:"name"`         // Name: label for the partition
-	ID           string   `yaml:"id"`           // ID: unique identifier for the partition; can be used as a key
-	Index        *int     `yaml:"index"`        // Index: index for the partition sdx (x = 1, 2, 3, 4, ...)
-	Flags        []string `yaml:"flags"`        // Flags: optional flags for the partition (e.g., "boot", "hidden")
-	Type         string   `yaml:"type"`         // Type: partition type (e.g., "esp", "linux-root-amd64")
-	TypeGUID     string   `yaml:"typeUUID"`     // TypeGUID: GPT type GUID for the partition (e.g., "8300" for Linux filesystem)
-	FsType       string   `yaml:"fsType"`       // FsType: filesystem type (e.g., "ext4", "xfs", etc.);
-	FsLabel      string   `yaml:"fsLabel"`      // FsLabel: filesystem label (e.g., "cloudimg-rootfs")
-	Start        string   `yaml:"start"`        // Start: start offset of the partition; can be a absolute size (e.g., "512MiB")
-	End          string   `yaml:"end"`          // End: end offset of the partition; can be a absolute size (e.g., "2GiB") or "0" for the end of the disk
-	MountPoint   string   `yaml:"mountPoint"`   // MountPoint: optional mount point for the partition (e.g., "/boot", "/rootfs")
-	MountOptions string   `yaml:"mountOptions"` // MountOptions: optional mount options for the partition (e.g., "defaults", "noatime")
+	Name         string   `yaml:"name"`            // Name: label for the partition
+	ID           string   `yaml:"id"`              // ID: unique identifier for the partition; can be used as a key
+	Index        *int     `yaml:"index,omitempty"` // Index: index for the partition sdx (x = 1, 2, 3, 4, ...)
+	Flags        []string `yaml:"flags"`           // Flags: optional flags for the partition (e.g., "boot", "hidden")
+	Type         string   `yaml:"type"`            // Type: partition type (e.g., "esp", "linux-root-amd64")
+	TypeGUID     string   `yaml:"typeUUID"`        // TypeGUID: GPT type GUID for the partition (e.g., "8300" for Linux filesystem)
+	FsType       string   `yaml:"fsType"`          // FsType: filesystem type (e.g., "ext4", "xfs", etc.);
+	FsLabel      string   `yaml:"fsLabel"`         // FsLabel: filesystem label (e.g., "cloudimg-rootfs")
+	Start        string   `yaml:"start"`           // Start: start offset of the partition; can be a absolute size (e.g., "512MiB")
+	End          string   `yaml:"end"`             // End: end offset of the partition; can be a absolute size (e.g., "2GiB") or "0" for the end of the disk
+	MountPoint   string   `yaml:"mountPoint"`      // MountPoint: optional mount point for the partition (e.g., "/boot", "/rootfs")
+	MountOptions string   `yaml:"mountOptions"`    // MountOptions: optional mount options for the partition (e.g., "defaults", "noatime")
 }
 
 var log = logger.Logger()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/open-edge-platform/image-composer-tool/internal/config/validate"
+	"gopkg.in/yaml.v3"
 )
 
 func intPtr(v int) *int { return &v }
@@ -4271,5 +4272,156 @@ func TestEnsureTempDir(t *testing.T) {
 	// Verify the directory was created
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		t.Error("EnsureTempDir should create the directory")
+	}
+}
+
+// TestSaveUpdatedConfigFileYAMLSerialization verifies that SaveUpdatedConfigFile
+// correctly serializes templates with partitions containing nil Index values,
+// ensuring that the YAML output omits the "index" key when Index is nil.
+func TestSaveUpdatedConfigFileYAMLSerialization(t *testing.T) {
+	// Create a template with partitions: one with nil Index, one with set Index
+	template := &ImageTemplate{
+		Image: ImageInfo{
+			Name:    "test-yaml-serialization",
+			Version: "1.0.0",
+		},
+		Target: TargetInfo{
+			OS:        "ubuntu",
+			Dist:      "ubuntu24",
+			Arch:      "x86_64",
+			ImageType: "raw",
+		},
+		Disk: DiskConfig{
+			Name:               "test-disk",
+			Size:               "10GB",
+			PartitionTableType: "gpt",
+			Partitions: []PartitionInfo{
+				{
+					Name:       "boot",
+					ID:         "boot-1",
+					Index:      intPtr(1), // Index explicitly set
+					Flags:      []string{"boot"},
+					Type:       "esp",
+					FsType:     "vfat",
+					FsLabel:    "boot",
+					Start:      "0",
+					End:        "512MiB",
+					MountPoint: "/boot",
+				},
+				{
+					Name:       "root",
+					ID:         "root-1",
+					Index:      nil, // Index is nil - should not appear in YAML
+					Flags:      []string{},
+					Type:       "linux-root-x86-64",
+					FsType:     "ext4",
+					FsLabel:    "rootfs",
+					Start:      "512MiB",
+					End:        "0",
+					MountPoint: "/",
+				},
+			},
+		},
+		SystemConfig: SystemConfig{
+			Name:        "test-system",
+			Description: "Test system config",
+			Bootloader: Bootloader{
+				BootType: "efi",
+				Provider: "grub2",
+			},
+			Kernel: KernelConfig{
+				Version: "6.1.0",
+			},
+		},
+	}
+
+	// Save to temporary file
+	tmpFile, err := os.CreateTemp("", "test-config-*.yml")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	tmpFile.Close()
+	defer os.Remove(tmpFile.Name())
+
+	// Save the template
+	err = template.SaveUpdatedConfigFile(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("SaveUpdatedConfigFile() = %v, want nil", err)
+	}
+
+	// Read the saved file and parse as YAML map
+	data, err := os.ReadFile(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to read saved file: %v", err)
+	}
+
+	// Parse YAML to verify structure
+	var parsed map[string]interface{}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Failed to parse YAML: %v", err)
+	}
+
+	// Navigate to partitions
+	disk, ok := parsed["disk"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("disk field not found or not a map")
+	}
+
+	partitionsRaw, ok := disk["partitions"].([]interface{})
+	if !ok {
+		t.Fatalf("partitions field not found or not a slice")
+	}
+
+	if len(partitionsRaw) != 2 {
+		t.Fatalf("expected 2 partitions, got %d", len(partitionsRaw))
+	}
+
+	// Check first partition (has Index set to 1)
+	partition1, ok := partitionsRaw[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("partition 0 not a map")
+	}
+
+	if index1, exists := partition1["index"]; !exists {
+		t.Error("first partition should have 'index' key since Index was set")
+	} else if index1 != 1 {
+		t.Errorf("first partition index should be 1, got %v", index1)
+	}
+
+	// Check second partition (has Index = nil)
+	partition2, ok := partitionsRaw[1].(map[string]interface{})
+	if !ok {
+		t.Fatalf("partition 1 not a map")
+	}
+
+	if _, exists := partition2["index"]; exists {
+		t.Error("second partition should NOT have 'index' key when Index is nil (omitempty)")
+	}
+
+	// Also verify raw YAML string doesn't contain "index: null" for the root partition
+	yamlStr := string(data)
+	lines := strings.Split(yamlStr, "\n")
+	inRootPartition := false
+	foundIndexNull := false
+
+	for i, line := range lines {
+		if strings.Contains(line, "- name: root") {
+			inRootPartition = true
+		} else if inRootPartition && strings.Contains(line, "- name:") {
+			// End of root partition, start of next
+			break
+		}
+
+		if inRootPartition && strings.TrimSpace(line) == "index:" {
+			// Check if followed by null or just "index:" with no value
+			if i+1 < len(lines) && strings.Contains(lines[i+1], "null") {
+				foundIndexNull = true
+				break
+			}
+		}
+	}
+
+	if foundIndexNull {
+		t.Error("YAML should not contain 'index: null' for partition with nil Index")
 	}
 }

--- a/internal/image/imagedisc/imagedisc.go
+++ b/internal/image/imagedisc/imagedisc.go
@@ -533,8 +533,16 @@ func diskPartitionCreate(
 		}
 
 		cmdStr := fmt.Sprintf("sudo sgdisk %s %s", strings.Join(parts, " "), diskPath)
-		_, err = shell.ExecCmd(cmdStr, false, shell.HostPath, nil)
+		cmdOutput, err := shell.ExecCmd(cmdStr, false, shell.HostPath, nil)
 		if err != nil {
+			trimmedOutput := strings.TrimSpace(cmdOutput)
+			if trimmedOutput != "" {
+				log.Errorf("Failed to create GPT partition %d on disk %s: %v; output: %s",
+					partitionNum, diskPath, err, trimmedOutput)
+				return "", fmt.Errorf("failed to create GPT partition %d on disk %s: %w; output: %s",
+					partitionNum, diskPath, err, trimmedOutput)
+			}
+
 			log.Errorf("Failed to create GPT partition %d on disk %s: %v", partitionNum, diskPath, err)
 			return "", fmt.Errorf("failed to create GPT partition %d on disk %s: %w", partitionNum, diskPath, err)
 		}
@@ -715,8 +723,15 @@ func DiskPartitionsCreate(diskPath string, partitionsList []config.PartitionInfo
 
 	if partitionTableType == "gpt" {
 		cmdStr := fmt.Sprintf("echo 'label: gpt' | sudo sfdisk %s", diskPath)
-		_, err := shell.ExecCmd(cmdStr, false, shell.HostPath, nil)
+		cmdOutput, err := shell.ExecCmd(cmdStr, false, shell.HostPath, nil)
 		if err != nil {
+			trimmedOutput := strings.TrimSpace(cmdOutput)
+			if trimmedOutput != "" {
+				log.Errorf("Failed to create GPT partition table on disk %s: %v; output: %s", diskPath, err, trimmedOutput)
+				return nil, fmt.Errorf("failed to create GPT partition table on disk %s: %w; output: %s",
+					diskPath, err, trimmedOutput)
+			}
+
 			log.Errorf("Failed to create GPT partition table on disk %s: %v", diskPath, err)
 			return nil, fmt.Errorf("failed to create GPT partition table on disk %s: %w", diskPath, err)
 		}

--- a/internal/image/imagedisc/imagedisc_test.go
+++ b/internal/image/imagedisc/imagedisc_test.go
@@ -1349,6 +1349,40 @@ func TestDiskPartitionsCreate_GPTLabelFailureWithOutput(t *testing.T) {
 			expectedErrMsg:   "failed to create GPT partition table",
 			checkOutputInErr: true,
 		},
+		{
+			name:     "gpt_label_failure_empty_output",
+			diskPath: "/dev/sdc",
+			partitionsList: []config.PartitionInfo{
+				{
+					ID:     "boot",
+					Start:  "0",
+					End:    "1GiB",
+					FsType: "fat32",
+					Type:   "esp",
+				},
+			},
+			commandOutput:    "",
+			expectError:      true,
+			expectedErrMsg:   "failed to create GPT partition table",
+			checkOutputInErr: false,
+		},
+		{
+			name:     "gpt_label_failure_whitespace_output",
+			diskPath: "/dev/sdd",
+			partitionsList: []config.PartitionInfo{
+				{
+					ID:     "root",
+					Start:  "0",
+					End:    "50GiB",
+					FsType: "ext4",
+					Type:   "linux",
+				},
+			},
+			commandOutput:    "   \n   ",
+			expectError:      true,
+			expectedErrMsg:   "failed to create GPT partition table",
+			checkOutputInErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1459,6 +1493,40 @@ func TestDiskPartitionCreate_SGDiskFailureWithOutput(t *testing.T) {
 			expectError:    true,
 			expectedErrMsg: "failed to create GPT partition 1",
 			checkOutputErr: true,
+		},
+		{
+			name:         "sgdisk_failure_empty_output",
+			diskPath:     "/dev/sdc",
+			partitionNum: 1,
+			partitionInfo: config.PartitionInfo{
+				ID:       "boot",
+				Start:    "0",
+				End:      "1GiB",
+				FsType:   "fat32",
+				Type:     "esp",
+				TypeGUID: "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+			},
+			sgdiskOutput:   "",
+			expectError:    true,
+			expectedErrMsg: "failed to create GPT partition 1",
+			checkOutputErr: false,
+		},
+		{
+			name:         "sgdisk_failure_whitespace_only_output",
+			diskPath:     "/dev/sdd",
+			partitionNum: 2,
+			partitionInfo: config.PartitionInfo{
+				ID:       "root",
+				Start:    "1GiB",
+				End:      "50GiB",
+				FsType:   "ext4",
+				Type:     "linux",
+				TypeGUID: "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+			},
+			sgdiskOutput:   "  \t  ",
+			expectError:    true,
+			expectedErrMsg: "failed to create GPT partition 2",
+			checkOutputErr: false,
 		},
 	}
 

--- a/internal/image/imagedisc/imagedisc_test.go
+++ b/internal/image/imagedisc/imagedisc_test.go
@@ -1299,6 +1299,7 @@ func TestGetSectorOffsetFromSize(t *testing.T) {
 		})
 	}
 }
+
 // TestDiskPartitionsCreate_GPTLabelFailureWithOutput tests the error path when GPT label creation
 // fails and stderr/stdout output is captured, ensuring the output is included in the error message.
 func TestDiskPartitionsCreate_GPTLabelFailureWithOutput(t *testing.T) {
@@ -1412,11 +1413,11 @@ func TestDiskPartitionCreate_SGDiskFailureWithOutput(t *testing.T) {
 			diskPath:     "/dev/sda",
 			partitionNum: 1,
 			partitionInfo: config.PartitionInfo{
-				ID:      "boot",
-				Start:   "0",
-				End:     "1GiB",
-				FsType:  "fat32",
-				Type:    "esp",
+				ID:       "boot",
+				Start:    "0",
+				End:      "1GiB",
+				FsType:   "fat32",
+				Type:     "esp",
 				TypeGUID: "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
 			},
 			sgdiskOutput:   "Error: The specified partition is not unique. Use option -p to point to the partition.",
@@ -1447,11 +1448,11 @@ func TestDiskPartitionCreate_SGDiskFailureWithOutput(t *testing.T) {
 			diskPath:     "/dev/sdb",
 			partitionNum: 1,
 			partitionInfo: config.PartitionInfo{
-				ID:      "data",
-				Start:   "0",
-				End:     "100GiB",
-				FsType:  "ext4",
-				Type:    "linux",
+				ID:       "data",
+				Start:    "0",
+				End:      "100GiB",
+				FsType:   "ext4",
+				Type:     "linux",
 				TypeGUID: "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
 			},
 			sgdiskOutput:   "  \n  Device not found  \n  ",

--- a/internal/image/imagedisc/imagedisc_test.go
+++ b/internal/image/imagedisc/imagedisc_test.go
@@ -1299,3 +1299,224 @@ func TestGetSectorOffsetFromSize(t *testing.T) {
 		})
 	}
 }
+// TestDiskPartitionsCreate_GPTLabelFailureWithOutput tests the error path when GPT label creation
+// fails and stderr/stdout output is captured, ensuring the output is included in the error message.
+func TestDiskPartitionsCreate_GPTLabelFailureWithOutput(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	tests := []struct {
+		name             string
+		diskPath         string
+		partitionsList   []config.PartitionInfo
+		commandOutput    string
+		expectError      bool
+		expectedErrMsg   string
+		checkOutputInErr bool
+	}{
+		{
+			name:     "gpt_label_failure_with_output",
+			diskPath: "/dev/sda",
+			partitionsList: []config.PartitionInfo{
+				{
+					ID:     "boot",
+					Start:  "0",
+					End:    "1GiB",
+					FsType: "fat32",
+					Type:   "esp",
+				},
+			},
+			commandOutput:    "Error: device busy, could not write GPT",
+			expectError:      true,
+			expectedErrMsg:   "failed to create GPT partition table",
+			checkOutputInErr: true,
+		},
+		{
+			name:     "gpt_label_failure_with_stderr",
+			diskPath: "/dev/sdb",
+			partitionsList: []config.PartitionInfo{
+				{
+					ID:     "root",
+					Start:  "0",
+					End:    "50GiB",
+					FsType: "ext4",
+					Type:   "linux",
+				},
+			},
+			commandOutput:    "sfdisk: cannot modify partition table",
+			expectError:      true,
+			expectedErrMsg:   "failed to create GPT partition table",
+			checkOutputInErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCommands := []shell.MockCommand{
+				// Mock the fdisk check for existing partitions (called by IsDiskPartitionExist)
+				{
+					Pattern: "fdisk -l",
+					Output:  "",
+					Error:   nil,
+				},
+				// Mock the sfdisk command for GPT label creation - this should fail with output
+				{
+					Pattern: "label: gpt",
+					Output:  tt.commandOutput,
+					Error:   fmt.Errorf("command failed"),
+				},
+			}
+			shell.Default = shell.NewMockExecutor(mockCommands)
+
+			_, err := DiskPartitionsCreate(tt.diskPath, tt.partitionsList, "gpt")
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error, but got none")
+				} else {
+					errMsg := err.Error()
+					if !strings.Contains(errMsg, tt.expectedErrMsg) {
+						t.Errorf("Expected error containing '%s', but got: %v", tt.expectedErrMsg, err)
+					}
+					if tt.checkOutputInErr && !strings.Contains(errMsg, tt.commandOutput) {
+						t.Errorf("Expected error to contain output '%s', but got: %v", tt.commandOutput, err)
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error, but got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestDiskPartitionCreate_SGDiskFailureWithOutput tests the error path when sgdisk fails
+// with command output, ensuring the trimmed output is included in the returned error.
+func TestDiskPartitionCreate_SGDiskFailureWithOutput(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	tests := []struct {
+		name           string
+		diskPath       string
+		partitionNum   int
+		partitionInfo  config.PartitionInfo
+		sgdiskOutput   string
+		expectError    bool
+		expectedErrMsg string
+		checkOutputErr bool
+	}{
+		{
+			name:         "sgdisk_partition_failure_with_stderr",
+			diskPath:     "/dev/sda",
+			partitionNum: 1,
+			partitionInfo: config.PartitionInfo{
+				ID:      "boot",
+				Start:   "0",
+				End:     "1GiB",
+				FsType:  "fat32",
+				Type:    "esp",
+				TypeGUID: "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+			},
+			sgdiskOutput:   "Error: The specified partition is not unique. Use option -p to point to the partition.",
+			expectError:    true,
+			expectedErrMsg: "failed to create GPT partition 1",
+			checkOutputErr: true,
+		},
+		{
+			name:         "sgdisk_failure_with_multiline_output",
+			diskPath:     "/dev/nvme0n1",
+			partitionNum: 2,
+			partitionInfo: config.PartitionInfo{
+				ID:       "root",
+				Start:    "1GiB",
+				End:      "50GiB",
+				FsType:   "ext4",
+				Type:     "linux",
+				Name:     "root_partition",
+				TypeGUID: "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+			},
+			sgdiskOutput:   "Warning: The CRC for the main GPT header is invalid\nError: Aborting due to invalid GPT",
+			expectError:    true,
+			expectedErrMsg: "failed to create GPT partition 2",
+			checkOutputErr: true,
+		},
+		{
+			name:         "sgdisk_failure_with_trailing_whitespace",
+			diskPath:     "/dev/sdb",
+			partitionNum: 1,
+			partitionInfo: config.PartitionInfo{
+				ID:      "data",
+				Start:   "0",
+				End:     "100GiB",
+				FsType:  "ext4",
+				Type:    "linux",
+				TypeGUID: "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+			},
+			sgdiskOutput:   "  \n  Device not found  \n  ",
+			expectError:    true,
+			expectedErrMsg: "failed to create GPT partition 1",
+			checkOutputErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Get disk name for the command mocks
+			diskName, _ := GetDiskNameFromDiskPath(tt.diskPath)
+
+			// Mock commands needed for diskPartitionCreate
+			mockCommands := []shell.MockCommand{
+				// Mock hw_sector_size read
+				{
+					Pattern: fmt.Sprintf("cat /sys/block/%s/queue/hw_sector_size", diskName),
+					Output:  "512\n",
+					Error:   nil,
+				},
+				// Mock physical_block_size read
+				{
+					Pattern: fmt.Sprintf("cat /sys/block/%s/queue/physical_block_size", diskName),
+					Output:  "4096\n",
+					Error:   nil,
+				},
+				// Mock sgdisk command - this should fail with output
+				{
+					Pattern: "sgdisk",
+					Output:  tt.sgdiskOutput,
+					Error:   fmt.Errorf("sgdisk command failed"),
+				},
+			}
+			shell.Default = shell.NewMockExecutor(mockCommands)
+
+			_, err := diskPartitionCreate(
+				tt.diskPath,
+				tt.partitionNum,
+				tt.partitionInfo,
+				"gpt",
+				"primary",
+			)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error, but got none")
+				} else {
+					errMsg := err.Error()
+					if !strings.Contains(errMsg, tt.expectedErrMsg) {
+						t.Errorf("Expected error containing '%s', but got: %v", tt.expectedErrMsg, err)
+					}
+					if tt.checkOutputErr {
+						trimmedOutput := strings.TrimSpace(tt.sgdiskOutput)
+						if trimmedOutput != "" && !strings.Contains(errMsg, trimmedOutput) {
+							t.Errorf("Expected error to contain trimmed output '%s', but got: %v", trimmedOutput, err)
+						}
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error, but got: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/image/imagedisc/loopdev_test.go
+++ b/internal/image/imagedisc/loopdev_test.go
@@ -1,0 +1,296 @@
+package imagedisc
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-edge-platform/image-composer-tool/internal/config"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/shell"
+)
+
+func TestNewLoopDev(t *testing.T) {
+	if NewLoopDev() == nil {
+		t.Fatal("expected non-nil loop device")
+	}
+}
+
+func TestLoopSetupCreate(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	tests := []struct {
+		name         string
+		output       string
+		cmdErr       error
+		expectError  bool
+		errorContains string
+	}{
+		{name: "success", output: "/dev/loop7\n"},
+		{name: "command error", cmdErr: fmt.Errorf("losetup failed"), expectError: true, errorContains: "losetup failed"},
+		{name: "unexpected output", output: "not-a-loop-device", expectError: true, errorContains: "failed to create loopback device"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shell.Default = shell.NewMockExecutor([]shell.MockCommand{
+				{Pattern: "losetup --direct-io=on --show -f -P", Output: tt.output, Error: tt.cmdErr},
+			})
+
+			got, err := loopSetupCreate("/tmp/test.raw")
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Fatalf("expected error to contain %q, got %v", tt.errorContains, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != "/dev/loop7" {
+				t.Fatalf("expected /dev/loop7, got %q", got)
+			}
+		})
+	}
+}
+
+func TestLoopSetupCreateEmptyRawDisk(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	t.Run("invalid size", func(t *testing.T) {
+		_, err := loopSetupCreateEmptyRawDisk(filepath.Join(t.TempDir(), "disk.raw"), "bad-size")
+		if err == nil {
+			t.Fatal("expected error for invalid size")
+		}
+	})
+
+	t.Run("missing file after create", func(t *testing.T) {
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{{Pattern: "fallocate", Output: "", Error: nil}})
+		_, err := loopSetupCreateEmptyRawDisk(filepath.Join(t.TempDir(), "disk.raw"), "16MiB")
+		if err == nil || !strings.Contains(err.Error(), "can't find") {
+			t.Fatalf("expected can't find error, got %v", err)
+		}
+	})
+}
+
+func TestLoopSetupDelete(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	t.Run("success", func(t *testing.T) {
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{{Pattern: "losetup -d /dev/loop7", Output: "", Error: nil}})
+		ld := &LoopDev{}
+		if err := ld.LoopSetupDelete("/dev/loop7"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("command error", func(t *testing.T) {
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{{Pattern: "losetup -d /dev/loop8", Output: "", Error: fmt.Errorf("delete failed")}})
+		ld := &LoopDev{}
+		err := ld.LoopSetupDelete("/dev/loop8")
+		if err == nil || !strings.Contains(err.Error(), "failed to delete loop device") {
+			t.Fatalf("expected wrapped delete error, got %v", err)
+		}
+	})
+}
+
+func TestLoopDevGetInfoAndHelpers(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	t.Run("get info success", func(t *testing.T) {
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{{
+			Pattern: "losetup -l /dev/loop1 --json",
+			Output:  `{"loopdevices":[{"name":"/dev/loop1","back-file":"/tmp/a.raw"}]}`,
+			Error:   nil,
+		}})
+
+		info, err := LoopDevGetInfo("/dev/loop1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if info["name"] != "/dev/loop1" {
+			t.Fatalf("unexpected info payload: %#v", info)
+		}
+	})
+
+	t.Run("get info invalid json", func(t *testing.T) {
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{{Pattern: "losetup -l /dev/loop2 --json", Output: "not-json", Error: nil}})
+		if _, err := LoopDevGetInfo("/dev/loop2"); err == nil {
+			t.Fatal("expected JSON error")
+		}
+	})
+
+	t.Run("get info no devices", func(t *testing.T) {
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{{Pattern: "losetup -l /dev/loop3 --json", Output: `{"loopdevices":[]}`, Error: nil}})
+		_, err := LoopDevGetInfo("/dev/loop3")
+		if err == nil || !strings.Contains(err.Error(), "no loop device info found") {
+			t.Fatalf("expected no info error, got %v", err)
+		}
+	})
+
+	t.Run("back-file success", func(t *testing.T) {
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{{
+			Pattern: "losetup -l /dev/loop4 --json",
+			Output:  `{"loopdevices":[{"back-file":"/tmp/b.raw"}]}`,
+			Error:   nil,
+		}})
+
+		backFile, err := LoopDevGetBackFile("/dev/loop4")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if backFile != "/tmp/b.raw" {
+			t.Fatalf("unexpected back-file: %q", backFile)
+		}
+	})
+
+	t.Run("back-file missing", func(t *testing.T) {
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{{
+			Pattern: "losetup -l /dev/loop5 --json",
+			Output:  `{"loopdevices":[{"name":"/dev/loop5"}]}`,
+			Error:   nil,
+		}})
+
+		_, err := LoopDevGetBackFile("/dev/loop5")
+		if err == nil || !strings.Contains(err.Error(), "back-file not found") {
+			t.Fatalf("expected back-file error, got %v", err)
+		}
+	})
+
+	t.Run("get all info", func(t *testing.T) {
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{{
+			Pattern: "losetup -l --json",
+			Output:  `{"loopdevices":[{"name":"/dev/loop1"},{"name":"/dev/loop2"}]}`,
+			Error:   nil,
+		}})
+
+		list, err := LoopDevGetInfoAll()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(list) != 2 {
+			t.Fatalf("expected 2 loop devices, got %d", len(list))
+		}
+	})
+
+	t.Run("get all info invalid json", func(t *testing.T) {
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{{Pattern: "losetup -l --json", Output: "bad-json", Error: nil}})
+		if _, err := LoopDevGetInfoAll(); err == nil {
+			t.Fatal("expected JSON error")
+		}
+	})
+}
+
+func TestGetLoopDevPathFromLoopDevPart(t *testing.T) {
+	tests := []struct {
+		input       string
+		expected    string
+		expectError bool
+	}{
+		{input: "/dev/loop0p1", expected: "/dev/loop0"},
+		{input: "/dev/loop12p8", expected: "/dev/loop12"},
+		{input: "/dev/sda1", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := GetLoopDevPathFromLoopDevPart(tt.input)
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestCreateRawImageLoopDev(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	t.Run("create loop device failure", func(t *testing.T) {
+		ld := &LoopDev{}
+		template := &config.ImageTemplate{Disk: config.DiskConfig{Size: "bad-size"}}
+		_, _, err := ld.CreateRawImageLoopDev(filepath.Join(t.TempDir(), "x.raw"), template)
+		if err == nil || !strings.Contains(err.Error(), "failed to create loop device") {
+			t.Fatalf("expected wrapped create loop error, got %v", err)
+		}
+	})
+
+	t.Run("successful create with empty partition list", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "disk.raw")
+
+		// Use shell mocks for all external commands touched in this path.
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{
+			{Pattern: "fallocate -l 1MiB", Output: "", Error: nil},
+			{Pattern: "losetup --direct-io=on --show -f -P", Output: "/dev/loop7\n", Error: nil},
+			{Pattern: "fdisk -l /dev/loop7", Output: "Disk /dev/loop7: 1 GiB", Error: nil},
+			{Pattern: "label: gpt", Output: "", Error: nil},
+		})
+
+		// Ensure the file exists for loopSetupCreateEmptyRawDisk stat check.
+		if err := os.WriteFile(filePath, []byte("raw"), 0600); err != nil {
+			t.Fatalf("failed to create placeholder raw file: %v", err)
+		}
+
+		ld := &LoopDev{}
+		template := &config.ImageTemplate{Disk: config.DiskConfig{Size: "1MiB", PartitionTableType: "gpt", Partitions: []config.PartitionInfo{}}}
+
+		loopPath, partMap, err := ld.CreateRawImageLoopDev(filePath, template)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if loopPath != "/dev/loop7" {
+			t.Fatalf("expected /dev/loop7, got %q", loopPath)
+		}
+		if len(partMap) != 0 {
+			t.Fatalf("expected empty partition map, got %#v", partMap)
+		}
+	})
+}
+
+func TestDiskPartitionDelete(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	t.Run("invalid index", func(t *testing.T) {
+		if err := diskPartitionDelete("/dev/sda", 0); err == nil {
+			t.Fatal("expected invalid partition number error")
+		}
+	})
+
+	t.Run("delete command failure", func(t *testing.T) {
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{{Pattern: "sfdisk --delete /dev/sda 1", Output: "", Error: fmt.Errorf("delete failed")}})
+		err := diskPartitionDelete("/dev/sda", 1)
+		if err == nil || !strings.Contains(err.Error(), "failed to delete partition 1") {
+			t.Fatalf("expected wrapped delete error, got %v", err)
+		}
+	})
+
+	t.Run("success with non-fatal partx failure", func(t *testing.T) {
+		shell.Default = shell.NewMockExecutor([]shell.MockCommand{
+			{Pattern: "sfdisk --delete /dev/sdb 2", Output: "", Error: nil},
+			{Pattern: "partx -d --nr 2 /dev/sdb", Output: "", Error: fmt.Errorf("already removed")},
+		})
+		if err := diskPartitionDelete("/dev/sdb", 2); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
+}

--- a/internal/image/imagedisc/loopdev_test.go
+++ b/internal/image/imagedisc/loopdev_test.go
@@ -22,10 +22,10 @@ func TestLoopSetupCreate(t *testing.T) {
 	defer func() { shell.Default = originalExecutor }()
 
 	tests := []struct {
-		name         string
-		output       string
-		cmdErr       error
-		expectError  bool
+		name          string
+		output        string
+		cmdErr        error
+		expectError   bool
 		errorContains string
 	}{
 		{name: "success", output: "/dev/loop7\n"},

--- a/internal/provider/ubuntu/ubuntu_test.go
+++ b/internal/provider/ubuntu/ubuntu_test.go
@@ -14,6 +14,15 @@ import (
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/system"
 )
 
+const ubuntuNetworkTestsEnv = "ICT_RUN_UBUNTU_NETWORK_TESTS"
+
+func requireUbuntuNetworkTests(t *testing.T) {
+	t.Helper()
+	if os.Getenv(ubuntuNetworkTestsEnv) != "1" {
+		t.Skipf("skipping network-dependent ubuntu provider test; set %s=1 to run", ubuntuNetworkTestsEnv)
+	}
+}
+
 // Helper function to create a test ImageTemplate
 func createTestImageTemplate() *config.ImageTemplate {
 	return &config.ImageTemplate{
@@ -75,6 +84,8 @@ func TestGetProviderId(t *testing.T) {
 
 // TestUbuntuProviderInit tests the Init method
 func TestUbuntuProviderInit(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Change to project root for tests that need config files
 	originalDir, _ := os.Getwd()
 	defer func() {
@@ -115,6 +126,8 @@ func TestUbuntuProviderInit(t *testing.T) {
 
 // TestUbuntuProviderInitArchMapping tests architecture mapping in Init
 func TestUbuntuProviderInitArchMapping(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Change to project root for tests that need config files
 	originalDir, _ := os.Getwd()
 	defer func() {
@@ -160,6 +173,8 @@ func TestUbuntuProviderInitArchMapping(t *testing.T) {
 
 // TestLoadRepoConfig tests the loadRepoConfig function
 func TestLoadRepoConfig(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Change to project root for tests that need config files
 	originalDir, _ := os.Getwd()
 	defer func() {
@@ -206,6 +221,8 @@ func TestLoadRepoConfig(t *testing.T) {
 
 // TestLoadRepoConfigUbuntu26 tests loading repo config for ubuntu26
 func TestLoadRepoConfigUbuntu26(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	originalDir, _ := os.Getwd()
 	defer func() {
 		if err := os.Chdir(originalDir); err != nil {
@@ -242,6 +259,8 @@ func TestLoadRepoConfigUbuntu26(t *testing.T) {
 
 // TestUbuntuProviderInitUbuntu26 tests Init with ubuntu26 dist
 func TestUbuntuProviderInitUbuntu26(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	originalDir, _ := os.Getwd()
 	defer func() {
 		if err := os.Chdir(originalDir); err != nil {
@@ -421,6 +440,8 @@ func TestUbuntuPostProcessCleanupErrorWrappedMessage(t *testing.T) {
 }
 
 func TestUbuntuInstallHostDependencySkipsExistingCommands(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()
 
@@ -435,6 +456,8 @@ func TestUbuntuInstallHostDependencySkipsExistingCommands(t *testing.T) {
 }
 
 func TestUbuntuInstallHostDependencyCommandCheckError(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()
 
@@ -477,6 +500,8 @@ func TestUbuntuDownloadImagePkgsUpdateSystemErrorDeterministic(t *testing.T) {
 }
 
 func TestUbuntuInstallHostDependencyInstallFailure(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()
 
@@ -500,6 +525,8 @@ func TestUbuntuInstallHostDependencyInstallFailure(t *testing.T) {
 
 // TestUbuntuProviderPreProcess tests PreProcess method with mocked dependencies
 func TestUbuntuProviderPreProcess(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Save original shell executor and restore after test
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()
@@ -551,6 +578,8 @@ func TestUbuntuProviderPreProcess(t *testing.T) {
 
 // TestUbuntuProviderBuildImage tests BuildImage method
 func TestUbuntuProviderBuildImage(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Save original shell executor and restore after test
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()
@@ -598,6 +627,8 @@ func TestUbuntuProviderBuildImage(t *testing.T) {
 
 // TestUbuntuProviderBuildImageISO tests BuildImage method with ISO type
 func TestUbuntuProviderBuildImageISO(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Save original shell executor and restore after test
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()
@@ -648,6 +679,8 @@ func TestUbuntuProviderBuildImageISO(t *testing.T) {
 
 // TestUbuntuProviderBuildImageInitrd tests BuildImage method with IMG type
 func TestUbuntuProviderBuildImageInitrd(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Save original shell executor and restore after test
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()
@@ -698,6 +731,8 @@ func TestUbuntuProviderBuildImageInitrd(t *testing.T) {
 
 // TestUbuntuProviderPostProcess tests PostProcess method
 func TestUbuntuProviderPostProcess(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Save original shell executor and restore after test
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()
@@ -747,6 +782,8 @@ func TestUbuntuProviderPostProcess(t *testing.T) {
 
 // TestUbuntuProviderInstallHostDependency tests installHostDependency method
 func TestUbuntuProviderInstallHostDependency(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Save original shell executor and restore after test
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()
@@ -829,6 +866,8 @@ func TestUbuntuProviderInstallHostDependencyCommands(t *testing.T) {
 
 // TestUbuntuProviderRegister tests the Register function
 func TestUbuntuProviderRegister(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Save original providers registry and restore after test
 	// Note: We can't easily access the provider registry for cleanup,
 	// so this test shows the approach but may leave test artifacts
@@ -862,6 +901,8 @@ func TestUbuntuProviderRegister(t *testing.T) {
 
 // TestUbuntuProviderWorkflow tests a complete ubuntu provider workflow
 func TestUbuntuProviderWorkflow(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// This is a unit test focused on testing the provider interface methods
 	// without external dependencies that require system access
 
@@ -939,6 +980,8 @@ func TestUbuntuConfigurationStructure(t *testing.T) {
 
 // TestUbuntuArchitectureHandling tests architecture-specific URL construction
 func TestUbuntuArchitectureHandling(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Change to project root for tests that need config files
 	originalDir, _ := os.Getwd()
 	defer func() {
@@ -1086,6 +1129,8 @@ func TestUbuntuPostProcessErrorHandling(t *testing.T) {
 
 // TestUbuntuDownloadImagePkgs tests downloadImagePkgs method structure
 func TestUbuntuDownloadImagePkgs(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	ubuntu := &ubuntu{
 		repoCfgs: []debutils.RepoConfig{
 			{
@@ -1121,6 +1166,8 @@ func TestUbuntuDownloadImagePkgs(t *testing.T) {
 
 // TestUbuntuMultipleRepositories tests handling of multiple repositories
 func TestUbuntuMultipleRepositories(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	ubuntu := &ubuntu{
 		repoCfgs: []debutils.RepoConfig{
 			{
@@ -1163,6 +1210,8 @@ func TestUbuntuMultipleRepositories(t *testing.T) {
 
 // TestUbuntuLoadRepoConfigMultiple tests loadRepoConfig with multiple repositories
 func TestUbuntuLoadRepoConfigMultiple(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Change to project root for tests that need config files
 	originalDir, _ := os.Getwd()
 	defer func() {
@@ -1223,6 +1272,8 @@ func TestUbuntuOsNameConstant(t *testing.T) {
 
 // TestUbuntuPreProcessWithMockEnv tests PreProcess with mock chroot environment
 func TestUbuntuPreProcessWithMockEnv(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	ubuntu := &ubuntu{
 		repoCfgs: []debutils.RepoConfig{
 			{
@@ -1279,6 +1330,8 @@ func TestUbuntuPostProcessWithMockEnv(t *testing.T) {
 
 // TestUbuntuInitWithAarch64 tests Init with aarch64 architecture mapping
 func TestUbuntuInitWithAarch64(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Change to project root for tests that need config files
 	originalDir, _ := os.Getwd()
 	defer func() {
@@ -1407,6 +1460,8 @@ func TestUbuntuBuildIsoImageError(t *testing.T) {
 
 // TestLoadRepoConfigArm64 tests loadRepoConfig with arm64 architecture
 func TestLoadRepoConfigArm64(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Change to project root for tests that need config files
 	originalDir, _ := os.Getwd()
 	defer func() {
@@ -1449,6 +1504,8 @@ func TestLoadRepoConfigArm64(t *testing.T) {
 
 // TestLoadRepoConfigNonDebRepository tests loadRepoConfig skipping non-DEB repos
 func TestLoadRepoConfigNonDebRepository(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// This test verifies that non-DEB repositories are properly skipped
 	// Change to project root for tests that need config files
 	originalDir, _ := os.Getwd()
@@ -1481,6 +1538,8 @@ func TestLoadRepoConfigNonDebRepository(t *testing.T) {
 
 // TestUbuntuRegisterWithEmptyDist tests Register with empty distribution
 func TestUbuntuRegisterWithEmptyDist(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Save original shell executor and restore after test
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()
@@ -1499,6 +1558,8 @@ func TestUbuntuRegisterWithEmptyDist(t *testing.T) {
 
 // TestUbuntuDownloadImagePkgsCacheDirError tests downloadImagePkgs cache dir error
 func TestUbuntuDownloadImagePkgsCacheDirError(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// This test verifies error handling when cache directory retrieval fails
 	ubuntu := &ubuntu{
 		repoCfgs: []debutils.RepoConfig{
@@ -1525,6 +1586,8 @@ func TestUbuntuDownloadImagePkgsCacheDirError(t *testing.T) {
 
 // TestUbuntuInitEmptyRepoConfigs tests Init handling when loadRepoConfig returns empty configs
 func TestUbuntuInitEmptyRepoConfigs(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// This test would need to mock loadRepoConfig to return empty configs
 	// For now, we document the expected behavior
 	ubuntu := &ubuntu{}
@@ -1578,6 +1641,8 @@ func TestUbuntuNameWithVariousInputs(t *testing.T) {
 
 // TestUbuntuInstallHostDependencyCommandCheck tests installHostDependency command checking
 func TestUbuntuInstallHostDependencyCommandCheck(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Save original shell executor and restore after test
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()
@@ -1608,6 +1673,8 @@ func TestUbuntuInstallHostDependencyCommandCheck(t *testing.T) {
 
 // TestUbuntuPreProcessInitChrootEnvError tests PreProcess when InitChrootEnv fails
 func TestUbuntuPreProcessInitChrootEnvError(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Create a mock that fails on InitChrootEnv
 	type failingMockChrootEnv struct {
 		mockChrootEnv
@@ -1709,6 +1776,8 @@ func TestUbuntuBuildIsoImageSuccess(t *testing.T) {
 
 // TestUbuntuPreProcessDownloadPackagesError tests PreProcess when downloadImagePkgs fails
 func TestUbuntuPreProcessDownloadPackagesError(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	ubuntu := &ubuntu{
 		repoCfgs:  []debutils.RepoConfig{}, // Empty to trigger error in downloadImagePkgs
 		chrootEnv: &mockChrootEnv{},
@@ -1729,6 +1798,8 @@ func TestUbuntuPreProcessDownloadPackagesError(t *testing.T) {
 
 // TestUbuntuDownloadImagePkgsUpdateSystemError tests downloadImagePkgs when UpdateSystemPkgs fails
 func TestUbuntuDownloadImagePkgsUpdateSystemError(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Create a mock that fails on UpdateSystemPkgs
 	type failingUpdateMockChrootEnv struct {
 		mockChrootEnv
@@ -1762,6 +1833,8 @@ func TestUbuntuDownloadImagePkgsUpdateSystemError(t *testing.T) {
 
 // TestLoadRepoConfigNoValidRepos tests loadRepoConfig when no valid repos found
 func TestLoadRepoConfigNoValidRepos(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Change to project root for tests that need config files
 	originalDir, _ := os.Getwd()
 	defer func() {
@@ -1814,6 +1887,8 @@ func TestUbuntuPostProcessCleanupError(t *testing.T) {
 
 // TestUbuntuRegisterWithDifferentArchitectures tests Register with various architectures
 func TestUbuntuRegisterWithDifferentArchitectures(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Save original shell executor and restore after test
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()
@@ -1847,6 +1922,8 @@ func TestUbuntuRegisterWithDifferentArchitectures(t *testing.T) {
 
 // TestUbuntuRegisterChrootEnvError tests Register when NewChrootEnv fails
 func TestUbuntuRegisterChrootEnvError(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Test with invalid parameters that should cause chroot creation to fail
 	err := Register("invalid-os", "invalid-dist", "invalid-arch")
 	if err != nil {
@@ -1859,6 +1936,8 @@ func TestUbuntuRegisterChrootEnvError(t *testing.T) {
 
 // TestUbuntuPreProcessWithMockComplete tests full PreProcess with comprehensive mocking
 func TestUbuntuPreProcessWithMockComplete(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Save original shell executor and restore after test
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()
@@ -1916,6 +1995,8 @@ func TestUbuntuPreProcessWithMockComplete(t *testing.T) {
 
 // TestUbuntuInstallHostDependencyMissingCommands tests installHostDependency when commands are missing
 func TestUbuntuInstallHostDependencyMissingCommands(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Save original shell executor and restore after test
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()
@@ -2066,6 +2147,8 @@ func TestUbuntuPostProcessNilTemplate(t *testing.T) {
 
 // TestUbuntuDownloadImagePkgsWithFullTemplate tests downloadImagePkgs with complete template
 func TestUbuntuDownloadImagePkgsWithFullTemplate(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	ubuntu := &ubuntu{
 		repoCfgs: []debutils.RepoConfig{
 			{
@@ -2110,6 +2193,8 @@ func TestUbuntuDownloadImagePkgsWithFullTemplate(t *testing.T) {
 
 // TestUbuntuLoadRepoConfigWithValidData tests loadRepoConfig with valid provider config
 func TestUbuntuLoadRepoConfigWithValidData(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Change to project root for tests that need config files
 	originalDir, _ := os.Getwd()
 	defer func() {
@@ -2160,6 +2245,8 @@ func TestUbuntuLoadRepoConfigWithValidData(t *testing.T) {
 
 // TestUbuntuInitWithX86_64Mapping tests Init with x86_64 to amd64 mapping
 func TestUbuntuInitWithX86_64Mapping(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Change to project root for tests that need config files
 	originalDir, _ := os.Getwd()
 	defer func() {
@@ -2198,6 +2285,8 @@ func TestUbuntuInitWithX86_64Mapping(t *testing.T) {
 
 // TestUbuntuPreProcessDownloadError tests PreProcess when downloadImagePkgs returns specific error
 func TestUbuntuPreProcessDownloadError(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Save original shell executor and restore after test
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()
@@ -2227,6 +2316,8 @@ func TestUbuntuPreProcessDownloadError(t *testing.T) {
 
 // TestUbuntuPreProcessInitChrootError tests PreProcess when InitChrootEnv returns error
 func TestUbuntuPreProcessInitChrootError(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// Create mock that fails on InitChrootEnv
 	type failingInitMock struct {
 		mockChrootEnv
@@ -2294,6 +2385,8 @@ func TestUbuntuBuildImageAllTypes(t *testing.T) {
 
 // TestUbuntuInstallHostDependencyGetPkgManagerError tests installHostDependency when GetHostOsPkgManager fails
 func TestUbuntuInstallHostDependencyGetPkgManagerError(t *testing.T) {
+	requireUbuntuNetworkTests(t)
+
 	// This test documents the error handling when system.GetHostOsPkgManager() fails
 	ubuntu := &ubuntu{}
 


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->
This PR addresses ISO installer reliability by aligning ISO mount labeling, improving installer debug logging, and ensuring required partitioning tools/config serialization behave correctly across supported distros.

Changes:

Improve GPT partitioning failure diagnostics by including command output in errors/logs.
Make PartitionInfo.index optional in emitted YAML (omitempty) to avoid serializing null.
Update ISO/initrd defaults and installer scripts (ISO label, partitioning tool packages, kernel cmdline, attended installer logging).

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->
Tested in build and then boot and installation in QEMU