### PR TITLE
Fix/live installer runtime robustness

### DIFF
--- a/cmd/live-installer/install.go
+++ b/cmd/live-installer/install.go
@@ -128,9 +128,49 @@ func dependencyCheck(targetOs string) error {
 	return nil
 }
 
+func targetUsesApt(targetOS string) bool {
+	switch targetOS {
+	case "ubuntu", "debian", "wind-river-elxr":
+		return true
+	default:
+		return false
+	}
+}
+
+func suppressHostAptBackgroundTasks() error {
+	systemctlExists, err := shell.IsCommandExist("systemctl", shell.HostPath)
+	if err != nil {
+		return fmt.Errorf("failed to check systemctl availability: %w", err)
+	}
+	if !systemctlExists {
+		log.Debugf("systemctl is not available; skipping host apt background task suppression")
+		return nil
+	}
+
+	commands := []string{
+		"sh -c \"systemctl stop apt-daily.service apt-daily.timer apt-daily-upgrade.service apt-daily-upgrade.timer unattended-upgrades.service unattended-upgrades.timer >/dev/null 2>&1 || true\"",
+		"sh -c \"systemctl mask apt-daily.service apt-daily.timer apt-daily-upgrade.service apt-daily-upgrade.timer unattended-upgrades.service unattended-upgrades.timer >/dev/null 2>&1 || true\"",
+	}
+
+	for _, cmd := range commands {
+		if _, err := shell.ExecCmd(cmd, true, shell.HostPath, nil); err != nil {
+			return fmt.Errorf("failed to suppress host apt background tasks: %w", err)
+		}
+	}
+
+	log.Infof("Suppressed host apt background services and timers")
+	return nil
+}
+
 func install(template *config.ImageTemplate, configDir, localRepo string) error {
 	if err := dependencyCheck(template.Target.OS); err != nil {
 		return fmt.Errorf("dependency check failed: %w", err)
+	}
+
+	if targetUsesApt(template.Target.OS) {
+		if err := suppressHostAptBackgroundTasks(); err != nil {
+			return fmt.Errorf("failed to suppress host apt background tasks: %w", err)
+		}
 	}
 
 	globalConfig.ConfigDir = configDir

--- a/cmd/live-installer/install.go
+++ b/cmd/live-installer/install.go
@@ -137,6 +137,50 @@ func targetUsesApt(targetOS string) bool {
 	}
 }
 
+var aptBackgroundUnits = []string{
+	"apt-daily.service",
+	"apt-daily.timer",
+	"apt-daily-upgrade.service",
+	"apt-daily-upgrade.timer",
+	"unattended-upgrades.service",
+	"unattended-upgrades.timer",
+}
+
+func isIgnorableSystemctlSuppressionFailure(output string) bool {
+	lowerOutput := strings.ToLower(strings.TrimSpace(output))
+	if lowerOutput == "" {
+		return false
+	}
+
+	markers := []string{
+		"not loaded",
+		"not found",
+		"does not exist",
+		"inactive",
+		"not active",
+	}
+
+	for _, marker := range markers {
+		if strings.Contains(lowerOutput, marker) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func runSystemctlSuppressionCommand(cmd string) error {
+	output, err := shell.ExecCmd(cmd, true, shell.HostPath, nil)
+	if err == nil {
+		return nil
+	}
+	if isIgnorableSystemctlSuppressionFailure(output) {
+		log.Warnf("Ignoring non-fatal systemctl suppression failure for %q: %s", cmd, strings.TrimSpace(output))
+		return nil
+	}
+	return fmt.Errorf("command %q failed: %w", cmd, err)
+}
+
 func suppressHostAptBackgroundTasks() error {
 	systemctlExists, err := shell.IsCommandExist("systemctl", shell.HostPath)
 	if err != nil {
@@ -148,12 +192,12 @@ func suppressHostAptBackgroundTasks() error {
 	}
 
 	commands := []string{
-		"sh -c \"systemctl stop apt-daily.service apt-daily.timer apt-daily-upgrade.service apt-daily-upgrade.timer unattended-upgrades.service unattended-upgrades.timer >/dev/null 2>&1 || true\"",
-		"sh -c \"systemctl mask apt-daily.service apt-daily.timer apt-daily-upgrade.service apt-daily-upgrade.timer unattended-upgrades.service unattended-upgrades.timer >/dev/null 2>&1 || true\"",
+		"systemctl stop " + strings.Join(aptBackgroundUnits, " "),
+		"systemctl mask --runtime " + strings.Join(aptBackgroundUnits, " "),
 	}
 
 	for _, cmd := range commands {
-		if _, err := shell.ExecCmd(cmd, true, shell.HostPath, nil); err != nil {
+		if err := runSystemctlSuppressionCommand(cmd); err != nil {
 			return fmt.Errorf("failed to suppress host apt background tasks: %w", err)
 		}
 	}

--- a/cmd/live-installer/install_test.go
+++ b/cmd/live-installer/install_test.go
@@ -8,7 +8,23 @@ import (
 	"testing"
 
 	"github.com/open-edge-platform/image-composer-tool/internal/config"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/shell"
 )
+
+func TestSuppressHostAptBackgroundTasks(t *testing.T) {
+	originalShell := shell.Default
+	defer func() { shell.Default = originalShell }()
+
+	shell.Default = shell.NewMockExecutor([]shell.MockCommand{
+		{Pattern: "command -v systemctl", Output: "/usr/bin/systemctl\n", Error: nil},
+		{Pattern: "systemctl stop apt-daily.service", Output: "", Error: nil},
+		{Pattern: "systemctl mask apt-daily.service", Output: "", Error: nil},
+	})
+
+	if err := suppressHostAptBackgroundTasks(); err != nil {
+		t.Fatalf("expected apt background suppression to succeed, got: %v", err)
+	}
+}
 
 func TestNewChrootBuilder_MissingConfigDir(t *testing.T) {
 	// Create a temporary directory for testing

--- a/cmd/live-installer/install_test.go
+++ b/cmd/live-installer/install_test.go
@@ -18,11 +18,52 @@ func TestSuppressHostAptBackgroundTasks(t *testing.T) {
 	shell.Default = shell.NewMockExecutor([]shell.MockCommand{
 		{Pattern: "command -v systemctl", Output: "/usr/bin/systemctl\n", Error: nil},
 		{Pattern: "systemctl stop apt-daily.service", Output: "", Error: nil},
-		{Pattern: "systemctl mask apt-daily.service", Output: "", Error: nil},
+		{Pattern: "systemctl mask --runtime apt-daily.service", Output: "", Error: nil},
 	})
 
 	if err := suppressHostAptBackgroundTasks(); err != nil {
 		t.Fatalf("expected apt background suppression to succeed, got: %v", err)
+	}
+}
+
+func TestSuppressHostAptBackgroundTasks_IgnoresMissingUnits(t *testing.T) {
+	originalShell := shell.Default
+	defer func() { shell.Default = originalShell }()
+
+	shell.Default = shell.NewMockExecutor([]shell.MockCommand{
+		{Pattern: "command -v systemctl", Output: "/usr/bin/systemctl\n", Error: nil},
+		{
+			Pattern: "systemctl stop apt-daily.service",
+			Output:  "Failed to stop unattended-upgrades.service: Unit unattended-upgrades.service not loaded.\n",
+			Error:   fmt.Errorf("exit status 5"),
+		},
+		{Pattern: "systemctl mask --runtime apt-daily.service", Output: "", Error: nil},
+	})
+
+	if err := suppressHostAptBackgroundTasks(); err != nil {
+		t.Fatalf("expected missing systemd units to be ignored, got: %v", err)
+	}
+}
+
+func TestSuppressHostAptBackgroundTasks_ReturnsRealFailure(t *testing.T) {
+	originalShell := shell.Default
+	defer func() { shell.Default = originalShell }()
+
+	shell.Default = shell.NewMockExecutor([]shell.MockCommand{
+		{Pattern: "command -v systemctl", Output: "/usr/bin/systemctl\n", Error: nil},
+		{
+			Pattern: "systemctl stop apt-daily.service",
+			Output:  "Failed to connect to bus: No such file or directory\n",
+			Error:   fmt.Errorf("exit status 1"),
+		},
+	})
+
+	err := suppressHostAptBackgroundTasks()
+	if err == nil {
+		t.Fatal("expected non-ignorable systemctl failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to suppress host apt background tasks") {
+		t.Fatalf("expected wrapped suppression failure, got: %v", err)
 	}
 }
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,9 +1,5 @@
 # Release Notes
 
-## Unreleased
-
-- Prevented the Ubuntu 24 unattended installer ISO from racing background `apt-daily` jobs by masking the related apt systemd services and timers in the live environment.
-
 ## Current Release
 
 **Version**: 1.0

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+
+- Prevented the Ubuntu 24 unattended installer ISO from racing background `apt-daily` jobs by masking the related apt systemd services and timers in the live environment.
+
 ## Current Release
 
 **Version**: 1.0

--- a/internal/image/imagedisc/imagedisc.go
+++ b/internal/image/imagedisc/imagedisc.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/open-edge-platform/image-composer-tool/internal/config"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/logger"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/mount"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/shell"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/slice"
 )
@@ -78,6 +79,109 @@ var partitionTypeNameToGUID = map[string]string{
 	"linux-raid":       "a19d880f-05fc-4d3b-a006-743f0f84911e",
 	"linux-luks":       "ca7d7ccb-63ed-4c53-861c-1742536059cc",
 	"linux-dm-crypt":   "7ffec5c9-2d00-49b7-8941-3ea10a5586b7",
+}
+
+func getStringValue(value interface{}) string {
+	strValue, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(strValue)
+}
+
+func isDiskInUsePartitioningOutput(output string) bool {
+	lowerOutput := strings.ToLower(output)
+	return strings.Contains(lowerOutput, "this disk is currently in use") ||
+		strings.Contains(lowerOutput, "checking that no-one is using this disk right now ... failed")
+}
+
+func releaseDiskForPartitioning(diskPath string) error {
+	partitions, err := DiskGetPartitionsInfo(diskPath)
+	if err != nil {
+		return fmt.Errorf("failed to inspect partitions on disk %s: %w", diskPath, err)
+	}
+
+	devInfo, err := DiskGetDevInfo(diskPath)
+	if err != nil {
+		return fmt.Errorf("failed to inspect device info for disk %s: %w", diskPath, err)
+	}
+
+	mountPoints := make([]string, 0, len(partitions)+1)
+	diskMountPoint := getStringValue(devInfo["mountpoint"])
+	if diskMountPoint != "" {
+		mountPoints = append(mountPoints, diskMountPoint)
+	}
+
+	for _, partition := range partitions {
+		mountPoint := getStringValue(partition["mountpoint"])
+		if mountPoint != "" {
+			mountPoints = append(mountPoints, mountPoint)
+		}
+	}
+
+	if len(mountPoints) > 0 {
+		sort.Sort(sort.Reverse(sort.StringSlice(mountPoints)))
+		for _, mountPoint := range mountPoints {
+			if err := mount.UmountPath(mountPoint); err != nil {
+				return fmt.Errorf("failed to unmount %s from disk %s: %w", mountPoint, diskPath, err)
+			}
+		}
+	}
+
+	for _, partition := range partitions {
+		partitionPath := getStringValue(partition["path"])
+		if partitionPath == "" {
+			continue
+		}
+		if output, err := shell.ExecCmd("swapoff "+partitionPath, true, shell.HostPath, nil); err != nil {
+			trimmedOutput := strings.TrimSpace(output)
+			if trimmedOutput != "" {
+				log.Debugf("swapoff skipped for %s on %s: %s", partitionPath, diskPath, trimmedOutput)
+			} else {
+				log.Debugf("swapoff skipped for %s on %s: %v", partitionPath, diskPath, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func createPartitionTable(diskPath, partitionTableType string) (string, error) {
+	label := "dos"
+	if partitionTableType == "gpt" {
+		label = "gpt"
+	}
+
+	cmdStr := fmt.Sprintf("echo 'label: %s' | sudo sfdisk %s", label, diskPath)
+	cmdOutput, err := shell.ExecCmd(cmdStr, false, shell.HostPath, nil)
+	if err == nil {
+		return cmdOutput, nil
+	}
+
+	trimmedOutput := strings.TrimSpace(cmdOutput)
+	if !isDiskInUsePartitioningOutput(trimmedOutput) {
+		return cmdOutput, err
+	}
+
+	log.Warnf("Disk %s reported busy during %s partition table creation; releasing disk and retrying with force", diskPath, partitionTableType)
+	if releaseErr := releaseDiskForPartitioning(diskPath); releaseErr != nil {
+		return cmdOutput, fmt.Errorf("failed to release busy disk %s before retry: %w", diskPath, releaseErr)
+	}
+
+	for _, retryCmd := range []string{
+		fmt.Sprintf("wipefs -a -f %s", diskPath),
+		"sync",
+		fmt.Sprintf("echo 'label: %s' | sudo sfdisk --force --wipe always %s", label, diskPath),
+	} {
+		var retryOutput string
+		retryOutput, err = shell.ExecCmd(retryCmd, true, shell.HostPath, nil)
+		cmdOutput = retryOutput
+		if err != nil {
+			return retryOutput, err
+		}
+	}
+
+	return cmdOutput, nil
 }
 
 // IsDigit checks if a string contains only digits
@@ -722,8 +826,7 @@ func DiskPartitionsCreate(diskPath string, partitionsList []config.PartitionInfo
 	}
 
 	if partitionTableType == "gpt" {
-		cmdStr := fmt.Sprintf("echo 'label: gpt' | sudo sfdisk %s", diskPath)
-		cmdOutput, err := shell.ExecCmd(cmdStr, false, shell.HostPath, nil)
+		cmdOutput, err := createPartitionTable(diskPath, partitionTableType)
 		if err != nil {
 			trimmedOutput := strings.TrimSpace(cmdOutput)
 			if trimmedOutput != "" {
@@ -779,8 +882,7 @@ func DiskPartitionsCreate(diskPath string, partitionsList []config.PartitionInfo
 		var partitionType string
 		var partitionNum int
 		maxPrimaryPartitionsNum := 4
-		cmdStr := fmt.Sprintf("echo 'label: dos' | sudo sfdisk %s", diskPath)
-		_, err := shell.ExecCmd(cmdStr, false, shell.HostPath, nil)
+		_, err := createPartitionTable(diskPath, partitionTableType)
 		if err != nil {
 			log.Errorf("Failed to create MBR partition table on disk %s: %v", diskPath, err)
 			return nil, fmt.Errorf("failed to create MBR partition table on disk %s: %w", diskPath, err)

--- a/internal/image/imagedisc/imagedisc.go
+++ b/internal/image/imagedisc/imagedisc.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 

--- a/internal/image/imagedisc/imagedisc_test.go
+++ b/internal/image/imagedisc/imagedisc_test.go
@@ -902,6 +902,45 @@ func TestDiskPartitionsCreate(t *testing.T) {
 	}
 }
 
+func TestDiskPartitionsCreate_GPTBusyDiskRetry(t *testing.T) {
+	originalExecutor := shell.Default
+	defer func() { shell.Default = originalExecutor }()
+
+	mockCommands := []shell.MockCommand{
+		{Pattern: ".*fdisk.*vda.*", Output: "Disk /dev/vda: 24 GiB", Error: nil},
+		{Pattern: ".*label.*gpt.*sfdisk /dev/vda", Output: "Checking that no-one is using this disk right now ... FAILED\n\nThis disk is currently in use - repartitioning is probably a bad idea.", Error: fmt.Errorf("busy")},
+		{Pattern: "lsblk /dev/vda", Output: `{"blockdevices":[{"name":"vda","path":"/dev/vda","type":"disk"},{"name":"vda1","path":"/dev/vda1","mountpoint":"/media/installer","type":"part"}]}`, Error: nil},
+		{Pattern: "mount", Output: "/dev/vda1 on /media/installer type ext4 (rw,relatime)", Error: nil},
+		{Pattern: "umount /media/installer", Output: "", Error: nil},
+		{Pattern: "swapoff /dev/vda1", Output: "", Error: fmt.Errorf("not swap")},
+		{Pattern: "wipefs -a -f /dev/vda", Output: "", Error: nil},
+		{Pattern: "sync", Output: "", Error: nil},
+		{Pattern: ".*label.*gpt.*sfdisk --force --wipe always /dev/vda", Output: "", Error: nil},
+		{Pattern: ".*hw_sector_size", Output: "512", Error: nil},
+		{Pattern: ".*physical_block_size", Output: "4096", Error: nil},
+		{Pattern: ".*sgdisk.*vda.*", Output: "", Error: nil},
+		{Pattern: ".*partx.*vda.*", Output: "", Error: nil},
+		{Pattern: ".*mkfs.*ext4.*vda.*", Output: "", Error: nil},
+	}
+	shell.Default = shell.NewMockExecutor(mockCommands)
+
+	result, err := DiskPartitionsCreate("/dev/vda", []config.PartitionInfo{{
+		ID:     "root",
+		Name:   "root",
+		Start:  "1MiB",
+		End:    "100MiB",
+		FsType: "ext4",
+		Type:   "linux",
+		Index:  intPtr(1),
+	}}, "gpt")
+	if err != nil {
+		t.Fatalf("expected busy disk retry to succeed, got: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 partition device after retry, got %d", len(result))
+	}
+}
+
 func TestGetPartitionLabel(t *testing.T) {
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()

--- a/internal/image/imageos/imageos_test.go
+++ b/internal/image/imageos/imageos_test.go
@@ -2457,8 +2457,8 @@ func TestMountDiskRootToChroot(t *testing.T) {
 
 	mockCommands := []shell.MockCommand{
 		// Specific test case behaviors - order matters, more specific patterns first
-		{Pattern: ".*mount.*xfs.*sdb1.*", Output: "", Error: fmt.Errorf("mount failed")},
-		{Pattern: ".*mount.*ext4.*sda1.*", Output: "", Error: nil},
+		{Pattern: ".*mount.*xfs.*image-rootfs-fail.*", Output: "", Error: fmt.Errorf("mount failed")},
+		{Pattern: ".*mount.*ext4.*image-rootfs-ok.*", Output: "", Error: nil},
 		// General mount commands - broad patterns to catch all mount utilities
 		{Pattern: ".*mount.*", Output: "", Error: nil},
 		{Pattern: ".*umount.*", Output: "", Error: nil},
@@ -2480,7 +2480,7 @@ func TestMountDiskRootToChroot(t *testing.T) {
 	}{
 		{
 			name:          "successful root mount",
-			diskPathIdMap: map[string]string{"root": "/dev/sda1"},
+			diskPathIdMap: map[string]string{"root": "image-rootfs-ok"},
 			partitions: []config.PartitionInfo{
 				{ID: "root", MountPoint: "/", FsType: "ext4"},
 			},
@@ -2488,7 +2488,7 @@ func TestMountDiskRootToChroot(t *testing.T) {
 		},
 		{
 			name:          "mount failure",
-			diskPathIdMap: map[string]string{"root": "/dev/sdb1"},
+			diskPathIdMap: map[string]string{"root": "image-rootfs-fail"},
 			partitions: []config.PartitionInfo{
 				{ID: "root", MountPoint: "/", FsType: "xfs"},
 			},

--- a/internal/utils/mount/mount.go
+++ b/internal/utils/mount/mount.go
@@ -53,11 +53,13 @@ func waitForBlockDevice(path string) error {
 }
 
 func mountPathWithRetry(targetPath, mountPoint, mountCmdStr string) error {
+	if err := waitForBlockDevice(targetPath); err != nil {
+		return err
+	}
+
 	var lastErr error
 	for attempt := 1; attempt <= maxBlockDeviceMountAttempts; attempt++ {
-		if err := waitForBlockDevice(targetPath); err != nil {
-			lastErr = err
-		} else if _, err := shell.ExecCmd(mountCmdStr, true, shell.HostPath, nil); err != nil {
+		if _, err := shell.ExecCmd(mountCmdStr, true, shell.HostPath, nil); err != nil {
 			lastErr = err
 			log.Warnf("Mount attempt %d/%d failed for %s on %s: %v", attempt, maxBlockDeviceMountAttempts, targetPath, mountPoint, err)
 		} else {

--- a/internal/utils/mount/mount.go
+++ b/internal/utils/mount/mount.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/logger"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/shell"
@@ -13,6 +14,62 @@ import (
 )
 
 var log = logger.Logger()
+
+const (
+	maxBlockDeviceMountAttempts = 5
+	blockDeviceRetryDelay       = 200 * time.Millisecond
+)
+
+func isBlockDevicePath(path string) bool {
+	return strings.HasPrefix(path, "/dev/")
+}
+
+func isBlockDeviceReady(path string) error {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat failed: %w", err)
+	}
+	mode := fileInfo.Mode()
+	if mode&os.ModeDevice == 0 || mode&os.ModeCharDevice != 0 {
+		return fmt.Errorf("path is not a block device")
+	}
+	return nil
+}
+
+func waitForBlockDevice(path string) error {
+	var lastErr error
+	for attempt := 1; attempt <= maxBlockDeviceMountAttempts; attempt++ {
+		if err := isBlockDeviceReady(path); err == nil {
+			return nil
+		} else {
+			lastErr = err
+			log.Debugf("Block device %s not ready on attempt %d/%d: %v", path, attempt, maxBlockDeviceMountAttempts, err)
+		}
+		if attempt < maxBlockDeviceMountAttempts {
+			time.Sleep(blockDeviceRetryDelay)
+		}
+	}
+	return fmt.Errorf("block device %s did not become ready after %d attempts: %w", path, maxBlockDeviceMountAttempts, lastErr)
+}
+
+func mountPathWithRetry(targetPath, mountPoint, mountCmdStr string) error {
+	var lastErr error
+	for attempt := 1; attempt <= maxBlockDeviceMountAttempts; attempt++ {
+		if err := waitForBlockDevice(targetPath); err != nil {
+			lastErr = err
+		} else if _, err := shell.ExecCmd(mountCmdStr, true, shell.HostPath, nil); err != nil {
+			lastErr = err
+			log.Warnf("Mount attempt %d/%d failed for %s on %s: %v", attempt, maxBlockDeviceMountAttempts, targetPath, mountPoint, err)
+		} else {
+			return nil
+		}
+
+		if attempt < maxBlockDeviceMountAttempts {
+			time.Sleep(blockDeviceRetryDelay)
+		}
+	}
+	return lastErr
+}
 
 func GetMountPathList() ([]string, error) {
 	var mountPathList []string
@@ -75,7 +132,11 @@ func MountPath(targetPath, mountPoint, mountFlags string) error {
 	}
 	if !pathExist {
 		mountCmdStr := "mount " + mountFlags + " " + targetPath + " " + mountPoint
-		if _, err := shell.ExecCmd(mountCmdStr, true, shell.HostPath, nil); err != nil {
+		if isBlockDevicePath(targetPath) {
+			if err := mountPathWithRetry(targetPath, mountPoint, mountCmdStr); err != nil {
+				return fmt.Errorf("failed to mount %s to %s after retries: %w", targetPath, mountPoint, err)
+			}
+		} else if _, err := shell.ExecCmd(mountCmdStr, true, shell.HostPath, nil); err != nil {
 			return fmt.Errorf("failed to mount %s to %s: %w", targetPath, mountPoint, err)
 		} else {
 			log.Debugf("Mounted:", targetPath, "to", mountPoint)

--- a/internal/utils/mount/mount.go
+++ b/internal/utils/mount/mount.go
@@ -160,16 +160,21 @@ func umountPath(mountPoint string) error {
 		{"umount -f " + mountPoint, "force"},
 		{"umount -lf " + mountPoint, "lazy-force"},
 	}
+	var lastErr error
 	for _, strategy := range unmountStrategies {
 		log.Debugf("Trying %s unmount for %s", strategy.desc, mountPoint)
 		if output, err := shell.ExecCmd(strategy.cmd, true, shell.HostPath, nil); err == nil {
 			log.Debugf("Successfully unmounted %s using %s approach", mountPoint, strategy.desc)
 			return nil
 		} else {
+			lastErr = err
 			log.Debugf("Unmount failed with %s approach: %v, output: %s", strategy.desc, err, output)
 		}
 	}
-	return nil
+	if lastErr != nil {
+		return fmt.Errorf("failed to unmount %s after trying all strategies: %w", mountPoint, lastErr)
+	}
+	return fmt.Errorf("failed to unmount %s after trying all strategies", mountPoint)
 }
 
 func UmountPath(mountPoint string) error {

--- a/internal/utils/mount/mount_test.go
+++ b/internal/utils/mount/mount_test.go
@@ -272,25 +272,25 @@ func TestMountPath(t *testing.T) {
 	}{
 		{
 			name:       "successful_mount_new_directory",
-			targetPath: "/dev/sda1",
+			targetPath: "image-rootfs",
 			mountPoint: "/mnt/test",
 			mountFlags: "-t ext4",
 			mockCommands: []shell.MockCommand{
 				{Pattern: "mkdir", Output: "", Error: nil},
 				{Pattern: "mount", Output: "", Error: nil}, // For IsMountPathExist check
-				{Pattern: "mount -t ext4 /dev/sda1 /mnt/test", Output: "", Error: nil},
+				{Pattern: "mount -t ext4 image-rootfs /mnt/test", Output: "", Error: nil},
 			},
 			expectError: false,
 		},
 		{
 			name:       "successful_mount_existing_directory",
-			targetPath: "/dev/sda1",
+			targetPath: "image-rootfs",
 			mountPoint: "/mnt/test",
 			mountFlags: "-t ext4",
 			mockCommands: []shell.MockCommand{
 				{Pattern: "mkdir", Output: "", Error: nil},
 				{Pattern: "mount", Output: "", Error: nil}, // For IsMountPathExist check
-				{Pattern: "mount -t ext4 /dev/sda1 /mnt/test", Output: "", Error: nil},
+				{Pattern: "mount -t ext4 image-rootfs /mnt/test", Output: "", Error: nil},
 			},
 			setupFunc: func(tempDir string) error {
 				return os.MkdirAll(filepath.Join(tempDir, "mnt", "test"), 0700)
@@ -299,7 +299,7 @@ func TestMountPath(t *testing.T) {
 		},
 		{
 			name:       "mount_already_exists",
-			targetPath: "/dev/sda1",
+			targetPath: "image-rootfs",
 			mountPoint: "/mnt/test",
 			mountFlags: "-t ext4",
 			mockCommands: []shell.MockCommand{
@@ -310,7 +310,7 @@ func TestMountPath(t *testing.T) {
 		},
 		{
 			name:       "mkdir_failure",
-			targetPath: "/dev/sda1",
+			targetPath: "image-rootfs",
 			mountPoint: "/mnt/test",
 			mountFlags: "-t ext4",
 			mockCommands: []shell.MockCommand{
@@ -321,20 +321,32 @@ func TestMountPath(t *testing.T) {
 		},
 		{
 			name:       "mount_command_failure",
-			targetPath: "/dev/sda1",
+			targetPath: "image-rootfs",
 			mountPoint: "/mnt/test",
 			mountFlags: "-t ext4",
 			mockCommands: []shell.MockCommand{
 				{Pattern: "mkdir -p", Output: "", Error: nil},
-				{Pattern: "mount.*/dev/sda1", Output: "", Error: fmt.Errorf("mount failed")},
+				{Pattern: "mount.*image-rootfs", Output: "", Error: fmt.Errorf("mount failed")},
 				{Pattern: "mount", Output: "", Error: nil}, // For IsMountPathExist check
 			},
 			expectError: true,
 			errorMsg:    "failed to mount",
 		},
 		{
+			name:       "block_device_not_ready",
+			targetPath: "/dev/missing-block-device",
+			mountPoint: "/mnt/test",
+			mountFlags: "-t vfat -o umask=0077",
+			mockCommands: []shell.MockCommand{
+				{Pattern: "mkdir -p", Output: "", Error: nil},
+				{Pattern: "mount", Output: "", Error: nil},
+			},
+			expectError: true,
+			errorMsg:    "did not become ready",
+		},
+		{
 			name:       "is_mount_path_exist_failure",
-			targetPath: "/dev/sda1",
+			targetPath: "image-rootfs",
 			mountPoint: "/mnt/test",
 			mountFlags: "-t ext4",
 			mockCommands: []shell.MockCommand{
@@ -358,7 +370,6 @@ func TestMountPath(t *testing.T) {
 					t.Fatalf("Failed to setup test: %v", err)
 				}
 			}
-
 			err := mount.MountPath(tt.targetPath, actualMountPoint, tt.mountFlags)
 
 			if tt.expectError {
@@ -910,37 +921,37 @@ func TestMountPath_EdgeCases(t *testing.T) {
 	}{
 		{
 			name:       "empty_mount_flags",
-			targetPath: "/dev/sda1",
+			targetPath: "image-rootfs",
 			mountPoint: "/mnt/test",
 			mountFlags: "",
 			mockCommands: []shell.MockCommand{
 				{Pattern: "mkdir -p /mnt/test", Output: "", Error: nil},
 				{Pattern: "mount", Output: "", Error: nil}, // IsMountPathExist check
-				{Pattern: "mount  /dev/sda1 /mnt/test", Output: "", Error: nil},
+				{Pattern: "mount  image-rootfs /mnt/test", Output: "", Error: nil},
 			},
 			expectError: false,
 		},
 		{
 			name:       "complex_mount_flags",
-			targetPath: "/dev/sda1",
+			targetPath: "image-rootfs",
 			mountPoint: "/mnt/test",
 			mountFlags: "-t ext4 -o rw,relatime,user_xattr",
 			mockCommands: []shell.MockCommand{
 				{Pattern: "mkdir -p /mnt/test", Output: "", Error: nil},
 				{Pattern: "mount", Output: "", Error: nil}, // IsMountPathExist check
-				{Pattern: "mount -t ext4 -o rw,relatime,user_xattr /dev/sda1 /mnt/test", Output: "", Error: nil},
+				{Pattern: "mount -t ext4 -o rw,relatime,user_xattr image-rootfs /mnt/test", Output: "", Error: nil},
 			},
 			expectError: false,
 		},
 		{
 			name:       "special_characters_in_paths",
-			targetPath: "/dev/disk/by-uuid/12345678-1234-1234-1234-123456789abc",
+			targetPath: "image-rootfs-12345678-1234-1234-1234-123456789abc",
 			mountPoint: "/mnt/test with spaces",
 			mountFlags: "-t ext4",
 			mockCommands: []shell.MockCommand{
 				{Pattern: "mkdir -p /mnt/test with spaces", Output: "", Error: nil},
 				{Pattern: "mount", Output: "", Error: nil}, // IsMountPathExist check
-				{Pattern: "mount -t ext4 /dev/disk/by-uuid/12345678-1234-1234-1234-123456789abc /mnt/test with spaces", Output: "", Error: nil},
+				{Pattern: "mount -t ext4 image-rootfs-12345678-1234-1234-1234-123456789abc /mnt/test with spaces", Output: "", Error: nil},
 			},
 			expectError: false,
 		},

--- a/internal/utils/mount/mount_test.go
+++ b/internal/utils/mount/mount_test.go
@@ -403,7 +403,7 @@ func TestUmountPath(t *testing.T) {
 			mountPoint: "/mnt/test",
 			mockCommands: []shell.MockCommand{
 				{Pattern: "mkdir", Output: "", Error: nil},
-				{Pattern: "mount", Output: "ext4 on /mnt/test type ext4 (rw,relatime)", Error: nil},
+				{Pattern: "^mount$", Output: "ext4 on /mnt/test type ext4 (rw,relatime)", Error: nil},
 				{Pattern: "umount /mnt/test", Output: "", Error: nil},
 			},
 			expectError: false,
@@ -413,7 +413,7 @@ func TestUmountPath(t *testing.T) {
 			mountPoint: "/mnt/test",
 			mockCommands: []shell.MockCommand{
 				{Pattern: "mkdir", Output: "", Error: nil},
-				{Pattern: "mount", Output: "ext4 on /mnt/test type ext4 (rw,relatime)", Error: nil},
+				{Pattern: "^mount$", Output: "ext4 on /mnt/test type ext4 (rw,relatime)", Error: nil},
 				{Pattern: "umount /mnt/test", Output: "", Error: fmt.Errorf("device busy")},
 				{Pattern: "umount -l /mnt/test", Output: "", Error: nil},
 			},
@@ -424,7 +424,7 @@ func TestUmountPath(t *testing.T) {
 			mountPoint: "/mnt/test",
 			mockCommands: []shell.MockCommand{
 				{Pattern: "mkdir", Output: "", Error: nil},
-				{Pattern: "mount", Output: "ext4 on /mnt/test type ext4 (rw,relatime)", Error: nil},
+				{Pattern: "^mount$", Output: "ext4 on /mnt/test type ext4 (rw,relatime)", Error: nil},
 				{Pattern: "umount /mnt/test", Output: "", Error: fmt.Errorf("device busy")},
 				{Pattern: "umount -l /mnt/test", Output: "", Error: fmt.Errorf("still busy")},
 				{Pattern: "umount -f /mnt/test", Output: "", Error: nil},
@@ -436,7 +436,7 @@ func TestUmountPath(t *testing.T) {
 			mountPoint: "/mnt/test",
 			mockCommands: []shell.MockCommand{
 				{Pattern: "mkdir", Output: "", Error: nil},
-				{Pattern: "mount", Output: "ext4 on /mnt/test type ext4 (rw,relatime)", Error: nil},
+				{Pattern: "^mount$", Output: "ext4 on /mnt/test type ext4 (rw,relatime)", Error: nil},
 				{Pattern: "umount /mnt/test", Output: "", Error: fmt.Errorf("device busy")},
 				{Pattern: "umount -l /mnt/test", Output: "", Error: fmt.Errorf("still busy")},
 				{Pattern: "umount -f /mnt/test", Output: "", Error: fmt.Errorf("still busy")},
@@ -449,13 +449,14 @@ func TestUmountPath(t *testing.T) {
 			mountPoint: "/mnt/test",
 			mockCommands: []shell.MockCommand{
 				{Pattern: "mkdir", Output: "", Error: nil},
-				{Pattern: "mount", Output: "ext4 on /mnt/test type ext4 (rw,relatime)", Error: nil},
+				{Pattern: "^mount$", Output: "ext4 on /mnt/test type ext4 (rw,relatime)", Error: nil},
 				{Pattern: "umount /mnt/test", Output: "", Error: fmt.Errorf("device busy")},
 				{Pattern: "umount -l /mnt/test", Output: "", Error: fmt.Errorf("still busy")},
 				{Pattern: "umount -f /mnt/test", Output: "", Error: fmt.Errorf("still busy")},
 				{Pattern: "umount -lf /mnt/test", Output: "", Error: fmt.Errorf("still busy")},
 			},
-			expectError: false, // umountPath returns nil even if all strategies fail
+			expectError: true,
+			errorMsg:    "failed to unmount /mnt/test after trying all strategies",
 		},
 		{
 			name:       "mount_point_not_mounted",
@@ -514,7 +515,7 @@ func TestUmountAndDeletePath(t *testing.T) {
 			name:       "successful_unmount_and_delete",
 			mountPoint: "/mnt/test",
 			mockCommands: []shell.MockCommand{
-				{Pattern: "mount", Output: "ext4 on /mnt/test type ext4 (rw,relatime)", Error: nil},
+				{Pattern: "^mount$", Output: "ext4 on /mnt/test type ext4 (rw,relatime)", Error: nil},
 				{Pattern: "umount /mnt/test", Output: "", Error: nil},
 				{Pattern: "rm -rf /mnt/test", Output: "", Error: nil},
 			},
@@ -586,7 +587,7 @@ func TestUmountSubPath(t *testing.T) {
 			name:       "successful_unmount_subpaths",
 			mountPoint: "/mnt/chroot",
 			mockCommands: []shell.MockCommand{
-				{Pattern: "mount", Output: "proc on /mnt/chroot/proc type proc (rw,nosuid,nodev,noexec,relatime)\ntmpfs on /mnt/chroot/dev/shm type tmpfs (rw,nosuid,nodev)\nudev on /mnt/chroot/dev type devtmpfs (rw,nosuid,relatime)\n", Error: nil},
+				{Pattern: "^mount$", Output: "proc on /mnt/chroot/proc type proc (rw,nosuid,nodev,noexec,relatime)\ntmpfs on /mnt/chroot/dev/shm type tmpfs (rw,nosuid,nodev)\nudev on /mnt/chroot/dev type devtmpfs (rw,nosuid,relatime)\n", Error: nil},
 				{Pattern: "umount /mnt/chroot/proc", Output: "", Error: nil},
 				{Pattern: "umount /mnt/chroot/dev/shm", Output: "", Error: nil},
 				{Pattern: "umount /mnt/chroot/dev", Output: "", Error: nil},
@@ -597,7 +598,7 @@ func TestUmountSubPath(t *testing.T) {
 			name:       "no_subpaths_to_unmount",
 			mountPoint: "/mnt/chroot",
 			mockCommands: []shell.MockCommand{
-				{Pattern: "mount", Output: "proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)\n", Error: nil},
+				{Pattern: "^mount$", Output: "proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)\n", Error: nil},
 			},
 			expectError: false,
 		},
@@ -605,7 +606,7 @@ func TestUmountSubPath(t *testing.T) {
 			name:       "get_mount_subpath_list_failure",
 			mountPoint: "/mnt/chroot",
 			mockCommands: []shell.MockCommand{
-				{Pattern: "mount", Output: "", Error: fmt.Errorf("mount command failed")},
+				{Pattern: "^mount$", Output: "", Error: fmt.Errorf("mount command failed")},
 			},
 			expectError: true,
 			errorMsg:    "failed to get mount subpath list",
@@ -614,13 +615,14 @@ func TestUmountSubPath(t *testing.T) {
 			name:       "unmount_subpath_failure",
 			mountPoint: "/mnt/chroot",
 			mockCommands: []shell.MockCommand{
-				{Pattern: "mount", Output: "proc on /mnt/chroot/proc type proc (rw,nosuid,nodev,noexec,relatime)\n", Error: nil},
+				{Pattern: "^mount$", Output: "proc on /mnt/chroot/proc type proc (rw,nosuid,nodev,noexec,relatime)\n", Error: nil},
 				{Pattern: "umount /mnt/chroot/proc", Output: "", Error: fmt.Errorf("device busy")},
 				{Pattern: "umount -l /mnt/chroot/proc", Output: "", Error: fmt.Errorf("still busy")},
 				{Pattern: "umount -f /mnt/chroot/proc", Output: "", Error: fmt.Errorf("still busy")},
 				{Pattern: "umount -lf /mnt/chroot/proc", Output: "", Error: fmt.Errorf("still busy")},
 			},
-			expectError: false, // umountPath returns nil even if all strategies fail
+			expectError: true,
+			errorMsg:    "failed to unmount /mnt/chroot/proc",
 		},
 	}
 

--- a/internal/utils/shell/shell.go
+++ b/internal/utils/shell/shell.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/logger"
 )
@@ -17,6 +18,18 @@ import (
 const HostPath string = "/"
 
 var log = logger.Logger()
+
+var (
+	aptLockRetryAttempts = 20
+	aptLockRetryDelay    = 3 * time.Second
+)
+
+var aptLockErrorMarkers = []string{
+	"could not get lock",
+	"unable to lock directory",
+	"unable to acquire the dpkg frontend lock",
+	"is another process using it",
+}
 
 var commandMap = map[string][]string{
 	"apt":                {"/usr/bin/apt"},
@@ -492,28 +505,7 @@ func (d *DefaultExecutor) ExecCmd(cmdStr string, sudo bool, chrootPath string, e
 		return "", fmt.Errorf("failed to get full command string: %w", err)
 	}
 
-	cmd := exec.Command("bash", "-c", fullCmdStr)
-	output, err := cmd.CombinedOutput()
-	outputStr := string(output)
-
-	if err != nil {
-		if outputStr != "" {
-			// return outputStr, fmt.Errorf("failed to exec %s: output %s, err %w", fullCmdStr, outputStr, err)
-			// Do not include the full command string in the error to avoid leaking sensitive data.
-			return outputStr, fmt.Errorf("failed to execute command with output: %w", err)
-		} else {
-			// return outputStr, fmt.Errorf("failed to exec %s: %w", fullCmdStr, err)
-			// Do not include the full command string in the error to avoid leaking sensitive data.
-			return outputStr, fmt.Errorf("failed to execute command: %w", err)
-		}
-	} else {
-		if outputStr != "" {
-			// log.Debugf(outputStr)
-			// Avoid logging raw command output to prevent leaking sensitive data.
-			log.Debugf("Command executed successfully with non-empty output")
-		}
-		return outputStr, nil
-	}
+	return d.execCmdWithRetry(cmdStr, fullCmdStr)
 }
 
 // ExecCmdSilent executes a command without logging its output
@@ -534,6 +526,97 @@ func (d *DefaultExecutor) ExecCmdWithStream(cmdStr string, sudo bool, chrootPath
 	if err != nil {
 		return "", fmt.Errorf("failed to get full command string: %w", err)
 	}
+
+	return d.execCmdWithStreamRetry(cmdStr, fullCmdStr)
+}
+
+func shouldRetryAptLock(cmdStr, output string, err error) bool {
+	if err == nil || aptLockRetryAttempts <= 1 {
+		return false
+	}
+
+	fields := strings.Fields(cmdStr)
+	if len(fields) == 0 {
+		return false
+	}
+
+	cmdName := fields[0]
+	if cmdName != "apt" && cmdName != "apt-get" {
+		return false
+	}
+
+	lowerOutput := strings.ToLower(output)
+	for _, marker := range aptLockErrorMarkers {
+		if strings.Contains(lowerOutput, marker) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func logAptRetry(attempt int, output string) {
+	trimmedOutput := strings.TrimSpace(output)
+	if trimmedOutput == "" {
+		log.Warnf("APT command hit a lock on attempt %d/%d; retrying in %s", attempt, aptLockRetryAttempts, aptLockRetryDelay)
+		return
+	}
+	log.Warnf("APT command hit a lock on attempt %d/%d; retrying in %s: %s",
+		attempt, aptLockRetryAttempts, aptLockRetryDelay, trimmedOutput)
+}
+
+func (d *DefaultExecutor) execCmdWithRetry(cmdStr, fullCmdStr string) (string, error) {
+	for attempt := 1; attempt <= aptLockRetryAttempts; attempt++ {
+		outputStr, err := d.execCmdOnce(fullCmdStr)
+		if err == nil {
+			return outputStr, nil
+		}
+		if !shouldRetryAptLock(cmdStr, outputStr, err) || attempt == aptLockRetryAttempts {
+			return outputStr, err
+		}
+		logAptRetry(attempt, outputStr)
+		time.Sleep(aptLockRetryDelay)
+	}
+
+	return "", fmt.Errorf("failed to execute command after retries")
+}
+
+func (d *DefaultExecutor) execCmdOnce(fullCmdStr string) (string, error) {
+	cmd := exec.Command("bash", "-c", fullCmdStr)
+	output, err := cmd.CombinedOutput()
+	outputStr := string(output)
+
+	if err != nil {
+		if outputStr != "" {
+			trimmedOutput := strings.TrimSpace(outputStr)
+			return outputStr, fmt.Errorf("failed to execute command with output %q: %w", trimmedOutput, err)
+		}
+		return outputStr, fmt.Errorf("failed to execute command: %w", err)
+	}
+
+	if outputStr != "" {
+		log.Debugf("Command executed successfully with non-empty output")
+	}
+	return outputStr, nil
+}
+
+func (d *DefaultExecutor) execCmdWithStreamRetry(cmdStr, fullCmdStr string) (string, error) {
+	for attempt := 1; attempt <= aptLockRetryAttempts; attempt++ {
+		outputStr, err := d.execCmdWithStreamOnce(fullCmdStr)
+		if err == nil {
+			return outputStr, nil
+		}
+		if !shouldRetryAptLock(cmdStr, outputStr, err) || attempt == aptLockRetryAttempts {
+			return outputStr, err
+		}
+		logAptRetry(attempt, outputStr)
+		time.Sleep(aptLockRetryDelay)
+	}
+
+	return "", fmt.Errorf("failed to execute streamed command after retries")
+}
+
+func (d *DefaultExecutor) execCmdWithStreamOnce(fullCmdStr string) (string, error) {
 	cmd := exec.Command("bash", "-c", fullCmdStr)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -548,7 +631,6 @@ func (d *DefaultExecutor) ExecCmdWithStream(cmdStr string, sudo bool, chrootPath
 		return "", fmt.Errorf("failed to start command %s: %w", fullCmdStr, err)
 	}
 
-	// Use channels to collect stdout and stderr in order to preserve full command output.
 	outputChan := make(chan string, 128)
 	var outputStr strings.Builder
 	var collectWG sync.WaitGroup
@@ -557,7 +639,7 @@ func (d *DefaultExecutor) ExecCmdWithStream(cmdStr string, sudo bool, chrootPath
 		defer collectWG.Done()
 		for output := range outputChan {
 			outputStr.WriteString(output)
-			outputStr.WriteString("\n") // Add newlines between lines
+			outputStr.WriteString("\n")
 		}
 	}()
 

--- a/internal/utils/shell/shell_retry_internal_test.go
+++ b/internal/utils/shell/shell_retry_internal_test.go
@@ -1,0 +1,51 @@
+package shell
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestExecCmdWithStream_RetriesAptLock(t *testing.T) {
+	tempDir := t.TempDir()
+	stateFile := filepath.Join(tempDir, "apt-state")
+	fakeAptPath := filepath.Join(tempDir, "apt")
+	script := fmt.Sprintf(`#!/bin/sh
+if [ ! -f %q ]; then
+  touch %q
+  echo "E: Could not get lock /var/lib/apt/lists/lock. It is held by process 358 (apt)" 1>&2
+  echo "E: Unable to lock directory /var/lib/apt/lists/" 1>&2
+  exit 100
+fi
+echo "updated"
+`, stateFile, stateFile)
+	if err := os.WriteFile(fakeAptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("failed to write fake apt script: %v", err)
+	}
+
+	originalAptPaths := commandMap["apt"]
+	originalAttempts := aptLockRetryAttempts
+	originalDelay := aptLockRetryDelay
+	defer func() {
+		commandMap["apt"] = originalAptPaths
+		aptLockRetryAttempts = originalAttempts
+		aptLockRetryDelay = originalDelay
+	}()
+
+	commandMap["apt"] = []string{fakeAptPath}
+	aptLockRetryAttempts = 2
+	aptLockRetryDelay = 10 * time.Millisecond
+
+	output, err := (&DefaultExecutor{}).ExecCmdWithStream("apt update", false, HostPath, nil)
+	if err != nil {
+		t.Fatalf("expected apt lock retry to succeed, got: %v", err)
+	}
+	if output != "updated\n" {
+		t.Fatalf("expected output to contain final successful apt output, got %q", output)
+	}
+	if _, err := os.Stat(stateFile); err != nil {
+		t.Fatalf("expected state file to exist after first failed attempt, got: %v", err)
+	}
+}

--- a/internal/utils/shell/shell_test.go
+++ b/internal/utils/shell/shell_test.go
@@ -87,6 +87,16 @@ func TestExecCmdOverride(t *testing.T) {
 	}
 }
 
+func TestExecCmdOverrideIncludesOutputInError(t *testing.T) {
+	_, err := shell.ExecCmd("sh -c \"echo lookup-blockdev-failed 1>&2; exit 32\"", false, shell.HostPath, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "lookup-blockdev-failed") {
+		t.Fatalf("expected error to include command output, got: %v", err)
+	}
+}
+
 func TestExecCmdSilentOverride(t *testing.T) {
 	originalExecutor := shell.Default
 	defer func() { shell.Default = originalExecutor }()


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [X] The changes in the PR have been built and tested
- [X] Documentation has been updated to reflect the changes (or no doc update needed)
- [X] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->
This PR pulls a set of installer/runtime robustness fixes into a standalone reviewable change, separate from the unattended ISO flow work.

It includes:
- suppressing host `apt-daily` / `unattended-upgrades` systemd units before apt-based installs begin
- retrying `apt` / `apt-get` commands when they fail on transient dpkg/apt lock contention
- preserving command output in shell execution errors to make failures diagnosable
- retrying block-device mounts until the device node is actually ready
- recovering from `sfdisk` "disk is currently in use" failures by releasing mounts/swap, wiping signatures, and retrying partition table creation with force
- focused tests covering the new retry/recovery paths

## Why

These failures are operational issues in the live installer path, but they are not specific to the unattended ISO script itself:

- background apt jobs can race package operations and hold dpkg/apt locks
- freshly created or discovered block devices are not always immediately mountable
- installer target disks can still be mounted or otherwise busy when repartitioning starts

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->
```bash
go test ./cmd/live-installer ./internal/image/imagedisc ./internal/utils/mount ./internal/utils/shell
```