### PR TITLE
improvement to disk selection policy

### DIFF
--- a/cmd/live-installer/install.go
+++ b/cmd/live-installer/install.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	attendedinstaller "github.com/open-edge-platform/image-composer-tool/cmd/live-installer/texture-ui"
 	"github.com/open-edge-platform/image-composer-tool/internal/chroot"
@@ -18,6 +19,43 @@ import (
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/security"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/shell"
 )
+
+// waitForDiskQuiescence waits for the disk to stabilize by checking for I/O inactivity.
+// This ensures hypervisors (QEMU, KVM, etc.) have fully initialized virtual disks before
+// partitioning begins. Returns nil if disk becomes quiescent or if check is not supported.
+func waitForDiskQuiescence(diskPath string) error {
+	const (
+		maxRetries = 20 // ~10 seconds with 500ms sleeps
+		sleepTime  = 500 * time.Millisecond
+	)
+
+	var quietCount int
+	const quietThreshold = 2 // Two consecutive checks with no I/O
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		isBusy, err := imagedisc.CheckDiskIOStats(diskPath)
+		if err != nil {
+			// If we can't read stats (e.g., disk not ready), skip quiescence check
+			return nil
+		}
+
+		if !isBusy {
+			quietCount++
+			if quietCount >= quietThreshold {
+				log.Debugf("Disk %s is quiescent after %d attempts", diskPath, attempt+1)
+				return nil
+			}
+		} else {
+			quietCount = 0
+		}
+
+		time.Sleep(sleepTime)
+	}
+
+	// Timeout reached; disk may not be fully quiescent, but proceed anyway (non-fatal)
+	log.Warnf("Disk %s did not reach quiescence within timeout; proceeding anyway", diskPath)
+	return nil
+}
 
 func newChrootBuilder(configDir, localRepo, targetOs, targetDist, targetArch string) (*chrootbuild.ChrootBuilder, error) {
 	var targetOsConfig map[string]interface{}
@@ -249,6 +287,14 @@ func install(template *config.ImageTemplate, configDir, localRepo string) error 
 	}
 	template.Disk.Path = diskPath
 	log.Infof("Using target disk: %s", diskPath)
+
+	// Wait for disk to stabilize before partitioning. QEMU and other hypervisors may take
+	// time to fully initialize virtual disks. Check for disk I/O quiescence (no active reads/writes)
+	// with a timeout to avoid indefinite waits.
+	log.Infof("Waiting for disk %s to stabilize...", diskPath)
+	if err := waitForDiskQuiescence(diskPath); err != nil {
+		log.Warnf("Disk quiescence check failed (continuing anyway): %v", err)
+	}
 
 	diskPathIdMap, err := imagedisc.DiskPartitionsCreate(diskPath, diskInfo.Partitions, diskInfo.PartitionTableType)
 	if err != nil {

--- a/cmd/live-installer/install.go
+++ b/cmd/live-installer/install.go
@@ -22,7 +22,9 @@ import (
 
 // waitForDiskQuiescence waits for the disk to stabilize by checking for I/O inactivity.
 // This ensures hypervisors (QEMU, KVM, etc.) have fully initialized virtual disks before
-// partitioning begins. Returns nil if disk becomes quiescent or if check is not supported.
+// partitioning begins. Errors from the I/O check are treated as "not-ready" (busy) and
+// retried until the timeout, preventing the check from being skipped on transient failures
+// such as /proc/diskstats not yet reporting the device.
 func waitForDiskQuiescence(diskPath string) error {
 	const (
 		maxRetries = 20 // ~10 seconds with 500ms sleeps
@@ -35,8 +37,12 @@ func waitForDiskQuiescence(diskPath string) error {
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		isBusy, err := imagedisc.CheckDiskIOStats(diskPath)
 		if err != nil {
-			// If we can't read stats (e.g., disk not ready), skip quiescence check
-			return nil
+			// Treat errors as busy/not-ready: the device may not yet be visible in
+			// /proc/diskstats. Reset quiet count and keep retrying until timeout.
+			log.Debugf("Disk %s I/O stats not yet available (attempt %d): %v", diskPath, attempt+1, err)
+			quietCount = 0
+			time.Sleep(sleepTime)
+			continue
 		}
 
 		if !isBusy {

--- a/cmd/live-installer/main.go
+++ b/cmd/live-installer/main.go
@@ -62,7 +62,6 @@ Use 'live-installer --help' to see available params.`,
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if !attendedInstaller {
-				logger.SetLogLevel("debug")
 				if err := unattendedInstall(config, repo); err != nil {
 					fmt.Fprintf(os.Stderr, "Unattended install failed: %v\n", err)
 					os.Exit(1)

--- a/config/general/isolinux/attendedinstaller
+++ b/config/general/isolinux/attendedinstaller
@@ -10,7 +10,7 @@ CACHE_REPO="$ISO_ROOT/cache-repo"
 
 # Mounting the ISO root for the installer.
 mkdir -p "$ISO_ROOT"
-LABELS=(ICT_CDROM OIC_CDROM)
+LABELS=(ICT_CDROM)
 
 function mount_iso_root {
     local label

--- a/config/general/isolinux/unattendedinstaller
+++ b/config/general/isolinux/unattendedinstaller
@@ -10,7 +10,7 @@ CACHE_REPO="$ISO_ROOT/cache-repo"
 
 # Mounting the ISO root for the installer.
 mkdir -p "$ISO_ROOT"
-LABELS=(ICT_CDROM OIC_CDROM)
+LABELS=(ICT_CDROM)
 
 function mount_iso_root {
     local label

--- a/image-templates/ubuntu24-x86_64-minimal-unattended-iso.yml
+++ b/image-templates/ubuntu24-x86_64-minimal-unattended-iso.yml
@@ -30,7 +30,7 @@ disk:
   selectionPolicy:
     strategy: largest
     excludeRemovable: true
-    requireEmpty: true # Only consider disks that do not have existing partitions or data.
+    requireEmpty: true # Only consider disks that do not have existing partitions.
   partitionTableType: gpt # Partition table type, valid value: [gpt, mbr]
   partitions:
     - id: boot

--- a/image-templates/ubuntu24-x86_64-minimal-unattended-iso.yml
+++ b/image-templates/ubuntu24-x86_64-minimal-unattended-iso.yml
@@ -30,6 +30,7 @@ disk:
   selectionPolicy:
     strategy: largest
     excludeRemovable: true
+    requireEmpty: true # Only consider disks that do not have existing partitions or data.
   partitionTableType: gpt # Partition table type, valid value: [gpt, mbr]
   partitions:
     - id: boot

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,9 @@ type DiskSelectionPolicy struct {
 	// ExcludeRemovable is intentionally conservative for unattended installs and
 	// excludes disks that appear externally attached, not only devices with RM=1.
 	ExcludeRemovable *bool `yaml:"excludeRemovable,omitempty"`
+	// RequireEmpty restricts unattended disk selection to empty disks when true.
+	// If false, disks with existing partitions are eligible and may be overwritten.
+	RequireEmpty *bool `yaml:"requireEmpty,omitempty"`
 }
 
 type DiskConfig struct {

--- a/internal/config/schema/os-image-template.schema.json
+++ b/internal/config/schema/os-image-template.schema.json
@@ -98,9 +98,9 @@
               "default": true
             },
             "requireEmpty": {
-              "type": "boolean",
-              "description": "Require the selected disk to be empty before installation. When false, installation may overwrite existing data on the selected disk.",
-              "default": true
+             "type": "boolean",
+             "description": "Require the selected disk to have no existing partitions before installation. This check does not detect raw or unpartitioned data already on the disk. When false, installation may overwrite existing data on the selected disk.",
+             "default": true
             }
           },
           "additionalProperties": false

--- a/internal/config/schema/os-image-template.schema.json
+++ b/internal/config/schema/os-image-template.schema.json
@@ -90,11 +90,16 @@
             "strategy": {
               "type": "string",
               "description": "Disk selection strategy",
-              "enum": ["first", "largest", "fastest", "largest-free"]
+              "enum": ["first", "largest", "fastest"]
             },
             "excludeRemovable": {
               "type": "boolean",
               "description": "Exclude removable or externally attached disks from selection using RM, transport, hotplug, udev, and sysfs heuristics",
+              "default": true
+            },
+            "requireEmpty": {
+              "type": "boolean",
+              "description": "Require the selected disk to be empty before installation. When false, installation may overwrite existing data on the selected disk.",
               "default": true
             }
           },

--- a/internal/image/imagedisc/imagedisc.go
+++ b/internal/image/imagedisc/imagedisc.go
@@ -49,10 +49,9 @@ type SystemBlockDevice struct {
 }
 
 const (
-	DiskSelectStrategyFirst       = "first"
-	DiskSelectStrategyLargest     = "largest"
-	DiskSelectStrategyFastest     = "fastest"
-	DiskSelectStrategyLargestFree = "largest-free"
+	DiskSelectStrategyFirst   = "first"
+	DiskSelectStrategyLargest = "largest"
+	DiskSelectStrategyFastest = "fastest"
 )
 
 const (
@@ -284,7 +283,6 @@ func TranslateBytesToSizeStr(byteSize uint64) string {
 		unit := uint64(sizeBytesMap[i])
 		if byteSize >= unit {
 			v := float64(byteSize) / float64(unit)
-			// trim trailing zeros as needed, here show up to 2 decimals
 			if v == float64(int64(v)) {
 				return fmt.Sprintf("%d%s", int64(v), sizeSuffixesList[i])
 			}
@@ -619,12 +617,25 @@ func diskPartitionCreate(
 		return "", fmt.Errorf("failed to get disk name from path: %s", diskPath)
 	}
 
-	startSector, _ := getSectorOffsetFromSize(diskName, startSizeStr)
+	var startSector uint64
+	if partitionInfo.Start == "0" {
+		startSector = 0
+	} else {
+		startSector, err = getSectorOffsetFromSize(diskName, startSizeStr)
+		if err != nil {
+			log.Errorf("Failed to calculate start sector for partition %d on disk %s: %v", partitionNum, diskPath, err)
+			return "", fmt.Errorf("failed to calculate start sector for partition %d on disk %s: %w", partitionNum, diskPath, err)
+		}
+	}
 	var endSector uint64
 	if partitionInfo.End == "0" {
 		endSector = 0
 	} else {
-		endSector, _ = getSectorOffsetFromSize(diskName, endSizeStr)
+		endSector, err = getSectorOffsetFromSize(diskName, endSizeStr)
+		if err != nil {
+			log.Errorf("Failed to calculate end sector for partition %d on disk %s: %v", partitionNum, diskPath, err)
+			return "", fmt.Errorf("failed to calculate end sector for partition %d on disk %s: %w", partitionNum, diskPath, err)
+		}
 		endSector--
 	}
 
@@ -1117,6 +1128,11 @@ func ResolveInstallDiskPath(diskConfig config.DiskConfig) (string, error) {
 		return "", err
 	}
 
+	strategy := strings.TrimSpace(strings.ToLower(diskConfig.SelectionPolicy.Strategy))
+	if strategy == "" {
+		return "", fmt.Errorf("disk path is not set and no selection policy strategy was provided")
+	}
+
 	// For backward compatibility, excludeRemovable now means exclude disks that
 	// appear externally attached according to multiple signals, not only the
 	// kernel's RM bit.
@@ -1125,186 +1141,142 @@ func ResolveInstallDiskPath(diskConfig config.DiskConfig) (string, error) {
 		excludeRemovable = *diskConfig.SelectionPolicy.ExcludeRemovable
 	}
 
-	eligible := make([]SystemBlockDevice, 0, len(devices))
-	for _, dev := range devices {
-		if excludeRemovable && dev.IsExternal {
-			continue
-		}
-		eligible = append(eligible, dev)
+	requireEmpty := true
+	if diskConfig.SelectionPolicy.RequireEmpty != nil {
+		requireEmpty = *diskConfig.SelectionPolicy.RequireEmpty
 	}
 
+	requiredDiskBytes, err := requiredInstallDiskBytes(diskConfig.Partitions)
+	if err != nil {
+		return "", fmt.Errorf("invalid partition layout for disk selection: %w", err)
+	}
+
+	eligible, evaluations := evaluateInstallDiskCandidates(devices, excludeRemovable, requireEmpty, requiredDiskBytes)
 	if len(eligible) == 0 {
-		return "", fmt.Errorf("no supported disks found after applying selection policy")
-	}
-
-	strategy := strings.TrimSpace(strings.ToLower(diskConfig.SelectionPolicy.Strategy))
-	if strategy == "" {
-		return "", fmt.Errorf("disk path is not set and no selection policy strategy was provided")
+		return "", fmt.Errorf("no eligible install disks matched selection policy (strategy=%s, requireEmpty=%t, excludeRemovable=%t)\n%s",
+			strategy, requireEmpty, excludeRemovable, formatDiskCandidateEvaluations(evaluations))
 	}
 
 	switch strategy {
 	case DiskSelectStrategyFirst:
 		return eligible[0].DevicePath, nil
 	case DiskSelectStrategyLargest:
-		selected := eligible[0]
-		for _, dev := range eligible[1:] {
-			if dev.RawDiskSize > selected.RawDiskSize {
-				selected = dev
+		sort.Slice(eligible, func(i, j int) bool {
+			if eligible[i].RawDiskSize != eligible[j].RawDiskSize {
+				return eligible[i].RawDiskSize > eligible[j].RawDiskSize
 			}
-		}
-		return selected.DevicePath, nil
-	case DiskSelectStrategyLargestFree:
-		return selectDiskWithLargestFreeSpan(eligible)
+			return eligible[i].DevicePath < eligible[j].DevicePath
+		})
+		return eligible[0].DevicePath, nil
 	case DiskSelectStrategyFastest:
-		selected := eligible[0]
-		for _, dev := range eligible[1:] {
-			if fasterDiskCandidate(dev, selected) {
-				selected = dev
-			}
+		if len(eligible) > 1 {
+			sort.Slice(eligible, func(i, j int) bool {
+				return fasterDiskCandidate(eligible[i], eligible[j])
+			})
 		}
-		return selected.DevicePath, nil
+		return eligible[0].DevicePath, nil
 	default:
 		return "", fmt.Errorf("unsupported disk selection strategy: %s", diskConfig.SelectionPolicy.Strategy)
 	}
 }
 
-type diskSpan struct {
-	start uint64
-	end   uint64
+type diskCandidateEvaluation struct {
+	Device  SystemBlockDevice
+	Reasons []string
 }
 
-func selectDiskWithLargestFreeSpan(devices []SystemBlockDevice) (string, error) {
-	if len(devices) == 0 {
-		return "", fmt.Errorf("no candidate disks provided")
-	}
+func requiredInstallDiskBytes(partitions []config.PartitionInfo) (uint64, error) {
+	var required uint64
+	for _, partition := range partitions {
+		endRaw := strings.TrimSpace(fmt.Sprintf("%v", partition.End))
+		if endRaw == "" || endRaw == "0" {
+			continue
+		}
 
-	selected := devices[0]
-	maxFreeSpan, err := largestFreeSpanBytes(selected.DevicePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to determine free space on %s: %w", selected.DevicePath, err)
-	}
-
-	for _, dev := range devices[1:] {
-		freeSpan, err := largestFreeSpanBytes(dev.DevicePath)
+		endSize, err := VerifyFileSize(partition.End)
 		if err != nil {
-			return "", fmt.Errorf("failed to determine free space on %s: %w", dev.DevicePath, err)
+			return 0, fmt.Errorf("partition %q has invalid end size %q: %w", partition.ID, endRaw, err)
 		}
 
-		if freeSpan > maxFreeSpan || (freeSpan == maxFreeSpan && dev.RawDiskSize > selected.RawDiskSize) {
-			selected = dev
-			maxFreeSpan = freeSpan
+		endBytes, err := TranslateSizeStrToBytes(endSize)
+		if err != nil {
+			return 0, fmt.Errorf("partition %q has invalid end size %q: %w", partition.ID, endRaw, err)
+		}
+
+		if endBytes > required {
+			required = endBytes
 		}
 	}
 
-	return selected.DevicePath, nil
+	return required, nil
 }
 
-func largestFreeSpanBytes(diskPath string) (uint64, error) {
-	diskInfo, err := DiskGetInfo(diskPath)
-	if err != nil {
-		return 0, fmt.Errorf("failed to inspect disk %s: %w", diskPath, err)
-	}
+func evaluateInstallDiskCandidates(
+	devices []SystemBlockDevice,
+	excludeRemovable, requireEmpty bool,
+	requiredDiskBytes uint64,
+) ([]SystemBlockDevice, []diskCandidateEvaluation) {
+	eligible := make([]SystemBlockDevice, 0, len(devices))
+	evaluations := make([]diskCandidateEvaluation, 0, len(devices))
 
-	totalSectorsRaw, ok := diskInfo["sectors"]
-	if !ok {
-		return 0, fmt.Errorf("disk info missing total sectors")
-	}
-	totalSectors, ok := totalSectorsRaw.(int)
-	if !ok || totalSectors <= 0 {
-		return 0, fmt.Errorf("invalid total sectors value: %v", totalSectorsRaw)
-	}
+	for _, dev := range devices {
+		reasons := make([]string, 0, 2)
 
-	logicalSizeRaw, ok := diskInfo["logical_size"]
-	if !ok {
-		return 0, fmt.Errorf("disk info missing logical sector size")
-	}
-	logicalSectorSize, err := parseBytesPrefix(fmt.Sprintf("%v", logicalSizeRaw))
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse logical sector size: %w", err)
-	}
+		if excludeRemovable && dev.IsExternal {
+			reasons = append(reasons, "excluded as externally attached/removable")
+		}
 
-	spans := []diskSpan{}
-	if partInfo, ok := diskInfo["part_info"].([]map[string]interface{}); ok {
-		for _, part := range partInfo {
-			start, err := parseUintField(part, "start_sec")
+		if requiredDiskBytes > 0 && dev.RawDiskSize < requiredDiskBytes {
+			reasons = append(reasons,
+				fmt.Sprintf("disk is too small (%d bytes) for requested layout end (%d bytes)", dev.RawDiskSize, requiredDiskBytes))
+		}
+
+		if requireEmpty {
+			partitionCount, err := diskPartitionCount(dev.DevicePath)
 			if err != nil {
-				return 0, err
+				reasons = append(reasons, fmt.Sprintf("could not verify emptiness: %v", err))
+			} else if partitionCount > 0 {
+				reasons = append(reasons, fmt.Sprintf("disk is not empty (%d partition(s) detected)", partitionCount))
 			}
-			end, err := parseUintField(part, "end_sec")
-			if err != nil {
-				return 0, err
-			}
-			if end < start {
-				return 0, fmt.Errorf("partition has end before start (%d < %d)", end, start)
-			}
-			spans = append(spans, diskSpan{start: start, end: end})
+		}
+
+		evaluations = append(evaluations, diskCandidateEvaluation{Device: dev, Reasons: reasons})
+		if len(reasons) == 0 {
+			eligible = append(eligible, dev)
 		}
 	}
 
-	if len(spans) == 0 {
-		return uint64(totalSectors) * uint64(logicalSectorSize), nil
-	}
-
-	sort.Slice(spans, func(i, j int) bool { return spans[i].start < spans[j].start })
-
-	total := uint64(totalSectors)
-	var maxGap uint64
-	var cursor uint64
-	for _, span := range spans {
-		if span.start > total {
-			break
-		}
-		if span.start > cursor {
-			gap := span.start - cursor
-			if gap > maxGap {
-				maxGap = gap
-			}
-		}
-		if span.end >= total {
-			cursor = total
-			break
-		}
-		next := span.end + 1
-		if next > cursor {
-			cursor = next
-		}
-	}
-
-	if cursor < total {
-		gap := total - cursor
-		if gap > maxGap {
-			maxGap = gap
-		}
-	}
-
-	return maxGap * uint64(logicalSectorSize), nil
+	return eligible, evaluations
 }
 
-func parseUintField(part map[string]interface{}, key string) (uint64, error) {
-	raw, ok := part[key]
-	if !ok {
-		return 0, fmt.Errorf("partition info missing %s", key)
-	}
-	value, err := strconv.ParseUint(fmt.Sprintf("%v", raw), 10, 64)
+func diskPartitionCount(diskPath string) (int, error) {
+	partitions, err := DiskGetPartitionsInfo(diskPath)
 	if err != nil {
-		return 0, fmt.Errorf("invalid %s value %v: %w", key, raw, err)
+		return 0, err
 	}
-	return value, nil
+	return len(partitions), nil
 }
 
-func parseBytesPrefix(s string) (int, error) {
-	fields := strings.Fields(s)
-	if len(fields) == 0 {
-		return 0, fmt.Errorf("empty size string")
+func formatDiskCandidateEvaluations(evaluations []diskCandidateEvaluation) string {
+	var builder strings.Builder
+	builder.WriteString("Disk candidates and policy evaluation:\n")
+
+	for _, evaluation := range evaluations {
+		device := evaluation.Device
+		builder.WriteString(fmt.Sprintf("- %s (size=%d bytes, transport=%s, model=%q): ",
+			device.DevicePath, device.RawDiskSize, strings.TrimSpace(device.Transport), strings.TrimSpace(device.Model)))
+
+		if len(evaluation.Reasons) == 0 {
+			builder.WriteString("eligible")
+		} else {
+			builder.WriteString("ineligible - ")
+			builder.WriteString(strings.Join(evaluation.Reasons, "; "))
+		}
+
+		builder.WriteString("\n")
 	}
-	value, err := strconv.Atoi(fields[0])
-	if err != nil {
-		return 0, fmt.Errorf("invalid size prefix %q: %w", fields[0], err)
-	}
-	if value <= 0 {
-		return 0, fmt.Errorf("size must be positive (got %d)", value)
-	}
-	return value, nil
+
+	return strings.TrimSuffix(builder.String(), "\n")
 }
 
 func fasterDiskCandidate(candidate, current SystemBlockDevice) bool {
@@ -1324,7 +1296,11 @@ func fasterDiskCandidate(candidate, current SystemBlockDevice) bool {
 		return candidateHasSSDHint
 	}
 
-	return candidate.RawDiskSize > current.RawDiskSize
+	if candidate.RawDiskSize != current.RawDiskSize {
+		return candidate.RawDiskSize > current.RawDiskSize
+	}
+
+	return candidate.DevicePath < current.DevicePath
 }
 
 func diskTransportTier(device SystemBlockDevice) int {

--- a/internal/image/imagedisc/imagedisc_test.go
+++ b/internal/image/imagedisc/imagedisc_test.go
@@ -1295,11 +1295,13 @@ func TestResolveInstallDiskPath(t *testing.T) {
 	}()
 
 	tests := []struct {
-		name        string
-		diskConfig  config.DiskConfig
-		lsblkOutput string
-		expectPath  string
-		expectError bool
+		name          string
+		diskConfig    config.DiskConfig
+		lsblkOutput   string
+		extraCommands []shell.MockCommand
+		expectPath    string
+		expectError   bool
+		errorContains string
 	}{
 		{
 			name:       "explicit_path_wins",
@@ -1315,7 +1317,7 @@ func TestResolveInstallDiskPath(t *testing.T) {
 		{
 			name: "largest_strategy_default",
 			diskConfig: config.DiskConfig{
-				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "largest"},
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "largest", RequireEmpty: boolPtr(false)},
 			},
 			lsblkOutput: `{"blockdevices":[{"name":"sda","size":10737418240,"model":"Disk A","serial":"A","tran":"sata","type":"disk","rm":0,"rota":1},{"name":"nvme0n1","size":21474836480,"model":"Disk B","serial":"B","tran":"nvme","type":"disk","rm":0,"rota":0}]}`,
 			expectPath:  "/dev/nvme0n1",
@@ -1323,23 +1325,23 @@ func TestResolveInstallDiskPath(t *testing.T) {
 		{
 			name: "fastest_strategy_prefers_nvme",
 			diskConfig: config.DiskConfig{
-				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "fastest"},
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "fastest", RequireEmpty: boolPtr(false)},
 			},
 			lsblkOutput: `{"blockdevices":[{"name":"sda","size":536870912000,"model":"Large HDD","serial":"A","tran":"sata","type":"disk","rm":0,"rota":1},{"name":"nvme0n1","size":107374182400,"model":"Fast NVMe","serial":"B","tran":"nvme","type":"disk","rm":0,"rota":0}]}`,
 			expectPath:  "/dev/nvme0n1",
 		},
 		{
-			name: "largest_free_strategy_uses_unallocated_span",
+			name: "fastest_strategy_picks_largest_within_fastest_tier",
 			diskConfig: config.DiskConfig{
-				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "largest-free"},
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "fastest", RequireEmpty: boolPtr(false)},
 			},
-			lsblkOutput: `{"blockdevices":[{"name":"sda","size":32212254720,"model":"Disk A","serial":"A","tran":"virtio","type":"disk","rm":0,"rota":0},{"name":"sdb","size":21474836480,"model":"Disk B","serial":"B","tran":"virtio","type":"disk","rm":0,"rota":0}]}`,
-			expectPath:  "/dev/sdb",
+			lsblkOutput: `{"blockdevices":[{"name":"nvme0n1","size":107374182400,"model":"Fast NVMe","serial":"A","tran":"nvme","type":"disk","rm":0,"rota":0},{"name":"nvme1n1","size":214748364800,"model":"Fast NVMe 2","serial":"B","tran":"nvme","type":"disk","rm":0,"rota":0},{"name":"sda","size":536870912000,"model":"Large HDD","serial":"C","tran":"sata","type":"disk","rm":0,"rota":1}]}`,
+			expectPath:  "/dev/nvme1n1",
 		},
 		{
 			name: "device_mapper_candidates_are_excluded",
 			diskConfig: config.DiskConfig{
-				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "first"},
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "first", RequireEmpty: boolPtr(false)},
 			},
 			lsblkOutput: `{"blockdevices":[{"name":"dm-0","size":21474836480,"model":"cryptroot","serial":"D","tran":"","type":"crypt","pkname":"nvme0n1","rm":0,"rota":0},{"name":"nvme0n1","size":21474836480,"model":"Fast NVMe","serial":"B","tran":"nvme","type":"disk","rm":0,"rota":0}]}`,
 			expectPath:  "/dev/nvme0n1",
@@ -1347,7 +1349,7 @@ func TestResolveInstallDiskPath(t *testing.T) {
 		{
 			name: "exclude_removable_default",
 			diskConfig: config.DiskConfig{
-				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "first"},
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "first", RequireEmpty: boolPtr(false)},
 			},
 			lsblkOutput: `{"blockdevices":[{"name":"sdb","size":68719476736,"model":"USB Disk","serial":"U","tran":"usb","type":"disk","rm":1,"rota":0},{"name":"sda","size":21474836480,"model":"Local","serial":"L","tran":"sata","type":"disk","rm":0,"rota":1}]}`,
 			expectPath:  "/dev/sda",
@@ -1355,7 +1357,7 @@ func TestResolveInstallDiskPath(t *testing.T) {
 		{
 			name: "exclude_external_hotplug_default",
 			diskConfig: config.DiskConfig{
-				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "first"},
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "first", RequireEmpty: boolPtr(false)},
 			},
 			lsblkOutput: `{"blockdevices":[{"name":"sdb","size":68719476736,"model":"USB Bridge","serial":"U","tran":"sata","type":"disk","hotplug":1,"rm":0,"rota":0},{"name":"sda","size":21474836480,"model":"Local","serial":"L","tran":"sata","type":"disk","hotplug":0,"rm":0,"rota":1}]}`,
 			expectPath:  "/dev/sda",
@@ -1363,15 +1365,123 @@ func TestResolveInstallDiskPath(t *testing.T) {
 		{
 			name: "include_external_when_enabled",
 			diskConfig: config.DiskConfig{
-				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "first", ExcludeRemovable: boolPtr(false)},
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "first", ExcludeRemovable: boolPtr(false), RequireEmpty: boolPtr(false)},
 			},
 			lsblkOutput: `{"blockdevices":[{"name":"sdb","size":68719476736,"model":"USB Disk","serial":"U","tran":"usb","type":"disk","rm":1,"rota":0},{"name":"sda","size":21474836480,"model":"Local","serial":"L","tran":"sata","type":"disk","rm":0,"rota":1}]}`,
 			expectPath:  "/dev/sdb",
 		},
 		{
+			name: "require_empty_false_allows_non_empty_disk",
+			diskConfig: config.DiskConfig{
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "first", RequireEmpty: boolPtr(false)},
+			},
+			lsblkOutput: `{"blockdevices":[{"name":"sda","size":21474836480,"model":"Disk A","serial":"A","tran":"sata","type":"disk","rm":0,"rota":1}]}`,
+			expectPath:  "/dev/sda",
+		},
+		{
+			name: "require_empty_filters_non_empty_disks",
+			diskConfig: config.DiskConfig{
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "first"},
+			},
+			lsblkOutput: `{"blockdevices":[{"name":"sda","size":21474836480,"model":"Disk A","serial":"A","tran":"sata","type":"disk","rm":0,"rota":1},{"name":"sdb","size":21474836480,"model":"Disk B","serial":"B","tran":"sata","type":"disk","rm":0,"rota":1}]}`,
+			extraCommands: []shell.MockCommand{
+				{Pattern: "lsblk /dev/sda --json --list --output", Output: `{"blockdevices":[{"name":"sda","path":"/dev/sda","type":"disk"},{"name":"sda1","path":"/dev/sda1","type":"part"}]}`, Error: nil},
+				{Pattern: "lsblk /dev/sdb --json --list --output", Output: `{"blockdevices":[{"name":"sdb","path":"/dev/sdb","type":"disk"}]}`, Error: nil},
+			},
+			expectPath: "/dev/sdb",
+		},
+		{
+			name: "no_eligible_candidates_reports_reasons",
+			diskConfig: config.DiskConfig{
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "first"},
+			},
+			lsblkOutput: `{"blockdevices":[{"name":"sda","size":21474836480,"model":"Local","serial":"A","tran":"sata","type":"disk","rm":0,"rota":1},{"name":"sdb","size":68719476736,"model":"USB Disk","serial":"B","tran":"usb","type":"disk","rm":1,"rota":0}]}`,
+			extraCommands: []shell.MockCommand{
+				{Pattern: "lsblk /dev/sda --json --list --output", Output: `{"blockdevices":[{"name":"sda","path":"/dev/sda","type":"disk"},{"name":"sda1","path":"/dev/sda1","type":"part"}]}`, Error: nil},
+				{Pattern: "lsblk /dev/sdb --json --list --output", Output: `{"blockdevices":[{"name":"sdb","path":"/dev/sdb","type":"disk"},{"name":"sdb1","path":"/dev/sdb1","type":"part"}]}`, Error: nil},
+			},
+			expectError:   true,
+			errorContains: "Disk candidates and policy evaluation",
+		},
+		{
+			name: "emptiness_probe_failure_reports_reason",
+			diskConfig: config.DiskConfig{
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "first"},
+			},
+			lsblkOutput: `{"blockdevices":[{"name":"sda","size":21474836480,"model":"Disk A","serial":"A","tran":"sata","type":"disk","rm":0,"rota":1}]}`,
+			extraCommands: []shell.MockCommand{
+				{Pattern: "lsblk /dev/sda --json --list --output", Output: "", Error: fmt.Errorf("lsblk probe failed")},
+			},
+			expectError:   true,
+			errorContains: "could not verify emptiness",
+		},
+		{
+			name: "fastest_equal_speed_and_size_uses_deterministic_tiebreak",
+			diskConfig: config.DiskConfig{
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "fastest", RequireEmpty: boolPtr(false)},
+			},
+			lsblkOutput: `{"blockdevices":[{"name":"nvme1n1","size":214748364800,"model":"Fast NVMe","serial":"B","tran":"nvme","type":"disk","rm":0,"rota":0},{"name":"nvme0n1","size":214748364800,"model":"Fast NVMe","serial":"A","tran":"nvme","type":"disk","rm":0,"rota":0}]}`,
+			expectPath:  "/dev/nvme0n1",
+		},
+		{
+			name: "largest_equal_size_uses_deterministic_tiebreak",
+			diskConfig: config.DiskConfig{
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "largest", RequireEmpty: boolPtr(false)},
+			},
+			lsblkOutput: `{"blockdevices":[{"name":"sdb","size":21474836480,"model":"Disk B","serial":"B","tran":"sata","type":"disk","rm":0,"rota":1},{"name":"sda","size":21474836480,"model":"Disk A","serial":"A","tran":"sata","type":"disk","rm":0,"rota":1}]}`,
+			expectPath:  "/dev/sda",
+		},
+		{
+			name: "exclude_removable_false_with_require_empty_true_can_select_external_empty",
+			diskConfig: config.DiskConfig{
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "first", ExcludeRemovable: boolPtr(false)},
+			},
+			lsblkOutput: `{"blockdevices":[{"name":"sda","size":21474836480,"model":"Local","serial":"A","tran":"sata","type":"disk","rm":0,"rota":1},{"name":"sdb","size":68719476736,"model":"USB Disk","serial":"B","tran":"usb","type":"disk","rm":1,"rota":0}]}`,
+			extraCommands: []shell.MockCommand{
+				{Pattern: "lsblk /dev/sda --json --list --output", Output: `{"blockdevices":[{"name":"sda","path":"/dev/sda","type":"disk"},{"name":"sda1","path":"/dev/sda1","type":"part"}]}`, Error: nil},
+				{Pattern: "lsblk /dev/sdb --json --list --output", Output: `{"blockdevices":[{"name":"sdb","path":"/dev/sdb","type":"disk"}]}`, Error: nil},
+			},
+			expectPath: "/dev/sdb",
+		},
+		{
+			name: "explicit_path_bypasses_policy_checks",
+			diskConfig: config.DiskConfig{
+				Path: "/dev/custom",
+				SelectionPolicy: config.DiskSelectionPolicy{
+					Strategy:     "first",
+					RequireEmpty: boolPtr(true),
+				},
+			},
+			expectPath: "/dev/custom",
+		},
+		{
+			name: "no_eligible_candidates_error_includes_policy_context",
+			diskConfig: config.DiskConfig{
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "largest"},
+			},
+			lsblkOutput: `{"blockdevices":[{"name":"sda","size":21474836480,"model":"Local","serial":"A","tran":"sata","type":"disk","rm":0,"rota":1}]}`,
+			extraCommands: []shell.MockCommand{
+				{Pattern: "lsblk /dev/sda --json --list --output", Output: `{"blockdevices":[{"name":"sda","path":"/dev/sda","type":"disk"},{"name":"sda1","path":"/dev/sda1","type":"part"}]}`, Error: nil},
+			},
+			expectError:   true,
+			errorContains: "strategy=largest, requireEmpty=true, excludeRemovable=true",
+		},
+		{
+			name: "disk_too_small_for_partition_layout_is_filtered_early",
+			diskConfig: config.DiskConfig{
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "first", RequireEmpty: boolPtr(false)},
+				Partitions: []config.PartitionInfo{
+					{ID: "boot", Start: "1MiB", End: "513MiB", FsType: "fat32"},
+				},
+			},
+			lsblkOutput:   `{"blockdevices":[{"name":"vda","size":536870912,"model":"Small Disk","serial":"A","tran":"virtio","type":"disk","rm":0,"rota":0}]}`,
+			expectError:   true,
+			errorContains: "disk is too small",
+		},
+		{
 			name: "unsupported_strategy",
 			diskConfig: config.DiskConfig{
-				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "by-id"},
+				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "by-id", RequireEmpty: boolPtr(false)},
 			},
 			lsblkOutput: `{"blockdevices":[{"name":"sda","size":21474836480,"model":"Disk","serial":"A","tran":"sata","type":"disk","rm":0,"rota":1}]}`,
 			expectError: true,
@@ -1390,25 +1500,8 @@ func TestResolveInstallDiskPath(t *testing.T) {
 				return "", os.ErrNotExist
 			}
 			if tt.diskConfig.Path == "" {
-				mockCommands := []shell.MockCommand{{Pattern: "lsblk", Output: tt.lsblkOutput, Error: nil}}
-				if tt.diskConfig.SelectionPolicy.Strategy == "largest-free" {
-					mockCommands = append(mockCommands,
-						shell.MockCommand{
-							Pattern: "fdisk -l /dev/sda",
-							Output: "Disk /dev/sda: 30 GiB, 32212254720 bytes, 62914560 sectors\n" +
-								"Sector size (logical/physical): 512 bytes / 512 bytes\n" +
-								"/dev/sda1        2048 60817407 60815360 29G Linux filesystem",
-							Error: nil,
-						},
-						shell.MockCommand{
-							Pattern: "fdisk -l /dev/sdb",
-							Output: "Disk /dev/sdb: 20 GiB, 21474836480 bytes, 41943040 sectors\n" +
-								"Sector size (logical/physical): 512 bytes / 512 bytes\n" +
-								"/dev/sdb1        2048 20973567 20971520 10G Linux filesystem",
-							Error: nil,
-						},
-					)
-				}
+				mockCommands := []shell.MockCommand{{Pattern: "lsblk -d --bytes", Output: tt.lsblkOutput, Error: nil}}
+				mockCommands = append(mockCommands, tt.extraCommands...)
 				shell.Default = shell.NewMockExecutor(mockCommands)
 			}
 
@@ -1416,6 +1509,9 @@ func TestResolveInstallDiskPath(t *testing.T) {
 			if tt.expectError {
 				if err == nil {
 					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Fatalf("expected error to contain %q, got %v", tt.errorContains, err)
 				}
 				return
 			}

--- a/internal/image/imagedisc/imagedisc_test.go
+++ b/internal/image/imagedisc/imagedisc_test.go
@@ -1371,12 +1371,25 @@ func TestResolveInstallDiskPath(t *testing.T) {
 			expectPath:  "/dev/sdb",
 		},
 		{
+			// Direct inverse of "require_empty_filters_non_empty_disks": identical two-disk fixture
+			// (sda has an existing partition sda1, sdb is empty) but with RequireEmpty=false.
+			// Under the default RequireEmpty=true policy sda is rejected and sdb is selected;
+			// here the emptiness probe is skipped entirely so sda — the first candidate — is
+			// selected instead, proving that a genuinely non-empty disk is accepted when the
+			// policy explicitly opts out of the emptiness requirement.
 			name: "require_empty_false_allows_non_empty_disk",
 			diskConfig: config.DiskConfig{
 				SelectionPolicy: config.DiskSelectionPolicy{Strategy: "first", RequireEmpty: boolPtr(false)},
 			},
-			lsblkOutput: `{"blockdevices":[{"name":"sda","size":21474836480,"model":"Disk A","serial":"A","tran":"sata","type":"disk","rm":0,"rota":1}]}`,
-			expectPath:  "/dev/sda",
+			lsblkOutput: `{"blockdevices":[{"name":"sda","size":21474836480,"model":"Disk A","serial":"A","tran":"sata","type":"disk","rm":0,"rota":1},{"name":"sdb","size":21474836480,"model":"Disk B","serial":"B","tran":"sata","type":"disk","rm":0,"rota":1}]}`,
+			// Partition probe mocks are not consumed (the probe is skipped when RequireEmpty=false)
+			// but document that sda is genuinely non-empty and sdb is empty — the same state that
+			// causes sda to be rejected in the RequireEmpty=true counterpart test below.
+			extraCommands: []shell.MockCommand{
+				{Pattern: "lsblk /dev/sda --json --list --output", Output: `{"blockdevices":[{"name":"sda","path":"/dev/sda","type":"disk"},{"name":"sda1","path":"/dev/sda1","type":"part"}]}`, Error: nil},
+				{Pattern: "lsblk /dev/sdb --json --list --output", Output: `{"blockdevices":[{"name":"sdb","path":"/dev/sdb","type":"disk"}]}`, Error: nil},
+			},
+			expectPath: "/dev/sda",
 		},
 		{
 			name: "require_empty_filters_non_empty_disks",


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [X] The changes in the PR have been built and tested
- [X] Documentation has been updated to reflect the changes (or no doc update needed)
- [X] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->
This PR resolves a critical issue where the unattended installer fails during disk partitioning in QEMU and other hypervisor environments. The root cause was a race condition: the installer attempted to partition the virtual disk before the hypervisor had fully initialized it, causing transient sgdisk failures ("Could not create partition...Error encountered; not saving changes").

The fix adds a disk quiescence check that waits for I/O activity to idle before attempting any partitioning operations, ensuring the kernel partition table is stable and ready. This is paired with broader robustness improvements to disk handling, logging behavior, and error propagation throughout the installation pipeline.

- Disk Quiescence Check: Added `waitForDiskQuiescence` in the live-installer that monitors `diskstats` and waits for 2 consecutive I/O-idle checks (with ~10-second timeout) before partitioning. This allows QEMU and similar hypervisors time to fully initialize virtual disks.
- Sector Calculation Error Handling: Replaced silent error suppression with explicit error checks and propagation in partition start/end sector calculations.
- Disk Policy Redesign: Removed largest-free strategy, added `requireEmpty` boolean field (defaults true) for candidate filtering, deterministic tie-breaking in fastest/largest selection, and clearer diagnostics when no eligible disks are found.
- Mount/Unmount Robustness: Flattened nested retry logic, fixed unmount error propagation, and improved error messages with context.
- Systemctl Suppression Safety: Changed from persistent masking to runtime masking with selective non-fatal error handling for absent units.

<!-- Fixes # (issue) -->
- Logging Behavior Correction: Fixed unattended mode to respect default INFO log level unless explicitly overridden via CLI [--log-level]
- ISO Bootloader Cleanup: Removed unused OIC_CDROM label references from isolinux scripts, keeping only ICT_CDROM.

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->
- All local unit-tests passing
- Booting ubuntu24-x86 unattended ISO live image