### PR TITLE
feat: add SWAP partition detection and cleanup before loop device detach

### DIFF
--- a/internal/image/imagedisc/loopdev.go
+++ b/internal/image/imagedisc/loopdev.go
@@ -54,11 +54,86 @@ func loopSetupCreateEmptyRawDisk(filePath, fileSize string) (string, error) {
 }
 
 func (loopDev *LoopDev) LoopSetupDelete(loopDevPath string) error {
+	// Handle SWAP partitions before detaching
+	if err := loopDev.disableSwapPartitions(loopDevPath); err != nil {
+		log.Warnf("Warning while disabling SWAP partitions on %s: %v", loopDevPath, err)
+		// Don't return error, try to continue with detach
+	}
+
 	cmd := fmt.Sprintf("losetup -d %s", loopDevPath)
 	if _, err := shell.ExecCmd(cmd, true, shell.HostPath, nil); err != nil {
 		log.Errorf("Failed to delete loop device %s: %v", loopDevPath, err)
 		return fmt.Errorf("failed to delete loop device %s: %w", loopDevPath, err)
 	}
+	return nil
+}
+
+// disableSwapPartitions finds and disables SWAP partitions on a loop device
+func (loopDev *LoopDev) disableSwapPartitions(loopDevPath string) error {
+	// List all partitions to find SWAP ones
+	// Get base loop device number from path (e.g., /dev/loop0 from /dev/loop0p1)
+	re := regexp.MustCompile(`^(/dev/loop\d+)(?:p\d+)?$`)
+	match := re.FindStringSubmatch(loopDevPath)
+	if len(match) < 2 {
+		// If not a loop device, no SWAP to disable
+		return nil
+	}
+
+	// Get all partitions of this loop device
+	cmd := fmt.Sprintf("lsblk -o NAME,FSTYPE %s -J", match[1])
+	output, err := shell.ExecCmd(cmd, true, shell.HostPath, nil)
+	if err != nil {
+		log.Debugf("Could not list block devices for %s: %v", match[1], err)
+		return nil
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		log.Debugf("Failed to parse lsblk output: %v", err)
+		return nil
+	}
+
+	// Recursively find and disable SWAP partitions
+	if err := loopDev.findAndDisableSwap(result); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// findAndDisableSwap recursively searches for SWAP filesystems and disables them
+func (loopDev *LoopDev) findAndDisableSwap(data interface{}) error {
+	switch v := data.(type) {
+	case map[string]interface{}:
+		// Check if this entry is a SWAP partition
+		if fsType, ok := v["fstype"].(string); ok && fsType == "swap" {
+			if name, ok := v["name"].(string); ok {
+				swapDev := fmt.Sprintf("/dev/%s", name)
+				log.Infof("Found SWAP partition: %s, disabling it", swapDev)
+				if _, err := shell.ExecCmd(fmt.Sprintf("swapoff %s", swapDev), true, shell.HostPath, nil); err != nil {
+					log.Warnf("Failed to disable SWAP on %s: %v", swapDev, err)
+					// Continue processing other partitions
+				} else {
+					log.Infof("Successfully disabled SWAP on %s", swapDev)
+				}
+			}
+		}
+
+		// Recurse into nested structures
+		for _, val := range v {
+			if err := loopDev.findAndDisableSwap(val); err != nil {
+				return err
+			}
+		}
+
+	case []interface{}:
+		for _, item := range v {
+			if err := loopDev.findAndDisableSwap(item); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [ ] The changes in the PR have been built and tested
- [ ] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
2026-05-19T11:36:11.361Z        INFO    imagedisc/loopdev.go:112        Found SWAP partition: /dev/loop32p2, disabling it
2026-05-19T11:36:11.378Z        INFO    imagedisc/loopdev.go:117        Successfully disabled SWAP on /dev/loop32p2
2026-05-19T11:36:11.383Z        INFO    rawmaker/rawmaker.go:133        Successfully detached loopback device: /dev/loop32
2026-05-19T11:36:11.383Z        INFO    display/display.go:21   Checking for image artifacts in: /home/user/riddhi/image-composer-tool/workspace/ubuntu-ubuntu24-x86_64/imagebuild/minimal