### PR TITLE
fix localrepo, offline cache and live-installer conflict

### DIFF
--- a/internal/chroot/chrootenv.go
+++ b/internal/chroot/chrootenv.go
@@ -344,6 +344,11 @@ func (chrootEnv *ChrootEnv) initChrootLocalRepo(targetArch string) error {
 			chrootPkgCacheDir, ChrootRepoDir, err)
 	}
 
+	if system.IsLiveInstallerExecution() {
+		log.Infof("Skipping local cache repository metadata/refresh in live-installer mode")
+		return nil
+	}
+
 	if chrootEnv.ChrootEnvRoot != shell.HostPath {
 		// Within iso initramfs system, local repo metadata should have been generated
 		// And the repo cache is read-only, not able to update by live-installer

--- a/internal/chroot/deb/installer.go
+++ b/internal/chroot/deb/installer.go
@@ -2,14 +2,16 @@ package deb
 
 import (
 	"fmt"
-	"github.com/open-edge-platform/image-composer-tool/internal/ospackage/debutils"
-	"github.com/open-edge-platform/image-composer-tool/internal/utils/logger"
-	"github.com/open-edge-platform/image-composer-tool/internal/utils/mount"
-	"github.com/open-edge-platform/image-composer-tool/internal/utils/shell"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/open-edge-platform/image-composer-tool/internal/ospackage/debutils"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/logger"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/mount"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/shell"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/system"
 )
 
 var log = logger.Logger()
@@ -133,6 +135,11 @@ func (debInstaller *DebInstaller) UpdateLocalDebRepo(repoPath, targetArch string
 	}
 	targetArch = normalizedArch
 	debInstaller.targetArch = normalizedArch
+
+	if system.IsLiveInstallerExecution() {
+		log.Infof("Skipping local DEB repository metadata update in live-installer mode")
+		return nil
+	}
 
 	metaDataPath := filepath.Join(repoPath,
 		fmt.Sprintf("dists/stable/main/binary-%s", targetArch), "Packages.gz")

--- a/internal/ospackage/debutils/download.go
+++ b/internal/ospackage/debutils/download.go
@@ -20,6 +20,7 @@ import (
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/logger"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/network"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/slice"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/system"
 )
 
 // Repository represents a Debian repository
@@ -117,6 +118,10 @@ func loadURLExistenceCacheLocked() {
 }
 
 func getURLExistenceFromCache(url string) (bool, bool) {
+	if system.IsLiveInstallerExecution() {
+		return false, false
+	}
+
 	urlExistenceCacheMu.Lock()
 	defer urlExistenceCacheMu.Unlock()
 
@@ -126,6 +131,10 @@ func getURLExistenceFromCache(url string) (bool, bool) {
 }
 
 func saveURLExistenceToCache(url string, exists bool) {
+	if system.IsLiveInstallerExecution() {
+		return
+	}
+
 	log := logger.Logger()
 
 	urlExistenceCacheMu.Lock()
@@ -170,6 +179,10 @@ func loadPackageListURLCacheLocked() {
 }
 
 func getPackageListURLFromCache(baseURL, codename, arch, component string) (string, bool) {
+	if system.IsLiveInstallerExecution() {
+		return "", false
+	}
+
 	packageListURLCacheMu.Lock()
 	defer packageListURLCacheMu.Unlock()
 
@@ -182,6 +195,10 @@ func getPackageListURLFromCache(baseURL, codename, arch, component string) (stri
 }
 
 func savePackageListURLToCache(baseURL, codename, arch, component, packageListURL string) {
+	if system.IsLiveInstallerExecution() {
+		return
+	}
+
 	log := logger.Logger()
 
 	packageListURLCacheMu.Lock()
@@ -349,6 +366,10 @@ func debMetadataBuildPaths() []string {
 }
 
 func loadDebPackageInfosFromMetadataCache() []ospackage.PackageInfo {
+	if system.IsLiveInstallerExecution() {
+		return nil
+	}
+
 	var infos []ospackage.PackageInfo
 	for _, dir := range debMetadataBuildPaths() {
 		cacheFile := filepath.Join(dir, "packages.parsed.json")

--- a/internal/ospackage/debutils/resolver.go
+++ b/internal/ospackage/debutils/resolver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/open-edge-platform/image-composer-tool/internal/ospackage"
 	"github.com/open-edge-platform/image-composer-tool/internal/ospackage/pkgfetcher"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/logger"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/system"
 )
 
 // VersionConstraint represents a version operator and version pair
@@ -169,9 +170,9 @@ func ParseRepositoryMetadata(baseURL string, pkggz string, releaseFile string, r
 	// Check the cache before any network operation. If a valid cache exists from a
 	// previous run it is returned immediately, enabling fully offline operation.
 	cacheFile := filepath.Join(pkgMetaDir, "packages.parsed.json")
-	allowParsedCache := !shouldBypassParsedPackageCache(baseURL)
+	allowParsedCache := !shouldBypassParsedPackageCache(baseURL) && !system.IsLiveInstallerExecution()
 	if !allowParsedCache {
-		log.Debugf("Bypassing parsed package metadata cache for loopback repository %s", baseURL)
+		log.Debugf("Bypassing parsed package metadata cache for %s", baseURL)
 	}
 	if allowParsedCache {
 		if cached, loadErr := loadParsedPackageCache(cacheFile); loadErr == nil && cached.Checksum != "" {

--- a/internal/ospackage/debutils/resolver.go
+++ b/internal/ospackage/debutils/resolver.go
@@ -117,6 +117,16 @@ type packageMetadataCache struct {
 	Packages []ospackage.PackageInfo `json:"packages"`
 }
 
+func shouldBypassParsedPackageCache(baseURL string) bool {
+	parsedURL, err := url.Parse(baseURL)
+	if err != nil {
+		return false
+	}
+
+	host := strings.ToLower(parsedURL.Hostname())
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
 func loadParsedPackageCache(cacheFile string) (*packageMetadataCache, error) {
 	data, err := os.ReadFile(cacheFile)
 	if err != nil {
@@ -159,9 +169,15 @@ func ParseRepositoryMetadata(baseURL string, pkggz string, releaseFile string, r
 	// Check the cache before any network operation. If a valid cache exists from a
 	// previous run it is returned immediately, enabling fully offline operation.
 	cacheFile := filepath.Join(pkgMetaDir, "packages.parsed.json")
-	if cached, loadErr := loadParsedPackageCache(cacheFile); loadErr == nil && cached.Checksum != "" {
-		log.Infof("Using cached package metadata for %s (checksum %s)", baseURL, cached.Checksum)
-		return cached.Packages, nil
+	allowParsedCache := !shouldBypassParsedPackageCache(baseURL)
+	if !allowParsedCache {
+		log.Debugf("Bypassing parsed package metadata cache for loopback repository %s", baseURL)
+	}
+	if allowParsedCache {
+		if cached, loadErr := loadParsedPackageCache(cacheFile); loadErr == nil && cached.Checksum != "" {
+			log.Infof("Using cached package metadata for %s (checksum %s)", baseURL, cached.Checksum)
+			return cached.Packages, nil
+		}
 	}
 
 	//verify release file
@@ -419,8 +435,10 @@ func ParseRepositoryMetadata(baseURL string, pkggz string, releaseFile string, r
 	}
 
 	// Persist the parsed result so future calls with the same checksum skip decompression/parsing.
-	if saveErr := saveParsedPackageCache(cacheFile, expectedChecksum, pkgs); saveErr != nil {
-		log.Warnf("failed to save package metadata cache: %v", saveErr)
+	if allowParsedCache {
+		if saveErr := saveParsedPackageCache(cacheFile, expectedChecksum, pkgs); saveErr != nil {
+			log.Warnf("failed to save package metadata cache: %v", saveErr)
+		}
 	}
 
 	return pkgs, nil

--- a/internal/ospackage/debutils/resolver_internal_test.go
+++ b/internal/ospackage/debutils/resolver_internal_test.go
@@ -1,7 +1,13 @@
 package debutils
 
 import (
+	"compress/gzip"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/open-edge-platform/image-composer-tool/internal/ospackage"
 )
 
 func TestIsGlobPattern(t *testing.T) {
@@ -130,6 +136,115 @@ func TestGetFullUrl(t *testing.T) {
 			}
 			if result != tt.expected {
 				t.Errorf("getFullUrl(%q, %q) = %q, want %q", tt.filePath, tt.baseUrl, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestShouldBypassParsedPackageCache(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseURL  string
+		expected bool
+	}{
+		{name: "localhost", baseURL: "http://localhost:123", expected: true},
+		{name: "localhost uppercase", baseURL: "http://LOCALHOST:123", expected: true},
+		{name: "ipv4 loopback", baseURL: "http://127.0.0.1:123", expected: true},
+		{name: "ipv6 loopback", baseURL: "http://[::1]:123", expected: true},
+		{name: "non-loopback", baseURL: "http://example.com:123", expected: false},
+		{name: "invalid url", baseURL: "://bad", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldBypassParsedPackageCache(tt.baseURL)
+			if got != tt.expected {
+				t.Errorf("shouldBypassParsedPackageCache(%q) = %v, want %v", tt.baseURL, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseRepositoryMetadata_ParsedCacheBypassForLoopback(t *testing.T) {
+	makeFixture := func(t *testing.T) string {
+		t.Helper()
+
+		buildPath := filepath.Join(t.TempDir(), "repo_main")
+		if err := os.MkdirAll(buildPath, 0755); err != nil {
+			t.Fatalf("failed to create build path: %v", err)
+		}
+
+		cachePkgs := []ospackage.PackageInfo{{Name: "cached-package", Version: "9.9.9", Type: "deb"}}
+		if err := saveParsedPackageCache(filepath.Join(buildPath, "packages.parsed.json"), "cached-checksum", cachePkgs); err != nil {
+			t.Fatalf("failed to write parsed package cache: %v", err)
+		}
+
+		pkggzPath := filepath.Join(buildPath, "Packages.gz")
+		pkgFile, err := os.Create(pkggzPath)
+		if err != nil {
+			t.Fatalf("failed to create Packages.gz: %v", err)
+		}
+
+		gzWriter := gzip.NewWriter(pkgFile)
+		packagesContent := "Package: live-package\nVersion: 1.2.3\nArchitecture: amd64\nFilename: pool/main/l/live-package/live-package_1.2.3_amd64.deb\n\n"
+		if _, err := gzWriter.Write([]byte(packagesContent)); err != nil {
+			_ = pkgFile.Close()
+			t.Fatalf("failed to write gzip content: %v", err)
+		}
+		if err := gzWriter.Close(); err != nil {
+			_ = pkgFile.Close()
+			t.Fatalf("failed to close gzip writer: %v", err)
+		}
+		if err := pkgFile.Close(); err != nil {
+			t.Fatalf("failed to close Packages.gz file: %v", err)
+		}
+
+		checksum, err := computeFileSHA256(pkggzPath)
+		if err != nil {
+			t.Fatalf("failed to compute Packages.gz checksum: %v", err)
+		}
+
+		releaseContent := fmt.Sprintf("SHA256:\n %s 1 main/binary-amd64/Packages.gz\n", checksum)
+		if err := os.WriteFile(filepath.Join(buildPath, "Release"), []byte(releaseContent), 0644); err != nil {
+			t.Fatalf("failed to write Release file: %v", err)
+		}
+
+		return buildPath
+	}
+
+	tests := []struct {
+		name        string
+		baseURL     string
+		expectedPkg string
+	}{
+		{name: "non-loopback uses parsed cache", baseURL: "http://example.com:123", expectedPkg: "cached-package"},
+		{name: "localhost bypasses parsed cache", baseURL: "http://localhost:123", expectedPkg: "live-package"},
+		{name: "127001 bypasses parsed cache", baseURL: "http://127.0.0.1:123", expectedPkg: "live-package"},
+		{name: "ipv6 loopback bypasses parsed cache", baseURL: "http://[::1]:123", expectedPkg: "live-package"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buildPath := makeFixture(t)
+
+			pkgs, err := ParseRepositoryMetadata(
+				tt.baseURL,
+				"Packages.gz",
+				"Release",
+				"Release.gpg",
+				"[trusted=yes]",
+				buildPath,
+				"amd64",
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("ParseRepositoryMetadata returned error: %v", err)
+			}
+			if len(pkgs) == 0 {
+				t.Fatalf("expected at least one package, got none")
+			}
+			if pkgs[0].Name != tt.expectedPkg {
+				t.Errorf("first package name = %q, want %q", pkgs[0].Name, tt.expectedPkg)
 			}
 		})
 	}

--- a/internal/ospackage/rpmutils/resolver.go
+++ b/internal/ospackage/rpmutils/resolver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/open-edge-platform/image-composer-tool/internal/ospackage"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/logger"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/network"
+	"github.com/open-edge-platform/image-composer-tool/internal/utils/system"
 )
 
 const (
@@ -351,18 +352,25 @@ func rpmMetadataCacheDir(baseURL string) (string, error) {
 // It also caches the downloaded and uncompressed XML files for debugging purposes.
 func ParseRepositoryMetadata(baseURL, gzHref string, packageFilter []string) ([]ospackage.PackageInfo, error) {
 	log := logger.Logger()
+	cacheEnabled := !system.IsLiveInstallerExecution()
 
 	fullURL := strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(gzHref, "/")
 	log.Infof("Fetching and parsing repository metadata from %s", fullURL)
 
 	// Keep metadata cache under persistent cache-dir so rebuilds can run offline.
-	xmlCacheDir, err := rpmMetadataCacheDir(baseURL)
-	if err != nil {
-		log.Warnf("Failed to resolve RPM metadata cache directory: %v", err)
-		xmlCacheDir = "" // Disable caching if cache root cannot be resolved
-	} else if err := os.MkdirAll(xmlCacheDir, 0755); err != nil {
-		log.Warnf("Failed to create XML cache directory: %v", err)
-		xmlCacheDir = "" // Disable caching if directory creation fails
+	xmlCacheDir := ""
+	if cacheEnabled {
+		var err error
+		xmlCacheDir, err = rpmMetadataCacheDir(baseURL)
+		if err != nil {
+			log.Warnf("Failed to resolve RPM metadata cache directory: %v", err)
+			xmlCacheDir = "" // Disable caching if cache root cannot be resolved
+		} else if err := os.MkdirAll(xmlCacheDir, 0755); err != nil {
+			log.Warnf("Failed to create XML cache directory: %v", err)
+			xmlCacheDir = "" // Disable caching if directory creation fails
+		}
+	} else {
+		log.Debugf("Bypassing RPM metadata cache in live-installer mode")
 	}
 
 	// Offline-first behavior: if parsed metadata is cached for this exact metadata URL,
@@ -674,18 +682,25 @@ func ParseRepositoryMetadata(baseURL, gzHref string, packageFilter []string) ([]
 func FetchPrimaryURL(repomdURL string) (string, error) {
 	log := logger.Logger()
 	baseURL := strings.TrimSuffix(repomdURL, "/repodata/repomd.xml")
+	cacheEnabled := !system.IsLiveInstallerExecution()
 
 	// Create cache directory for repomd-derived artifacts.
-	xmlCacheDir, cacheDirErr := rpmMetadataCacheDir(baseURL)
-	if cacheDirErr != nil {
-		log.Warnf("Failed to resolve RPM metadata cache directory: %v", cacheDirErr)
-		xmlCacheDir = ""
-	}
-	if xmlCacheDir != "" {
-		if err := os.MkdirAll(xmlCacheDir, 0755); err != nil {
-			log.Warnf("Failed to create XML cache directory: %v", err)
-			xmlCacheDir = ""
+	xmlCacheDir := ""
+	if cacheEnabled {
+		cacheDir, cacheDirErr := rpmMetadataCacheDir(baseURL)
+		if cacheDirErr != nil {
+			log.Warnf("Failed to resolve RPM metadata cache directory: %v", cacheDirErr)
+		} else {
+			xmlCacheDir = cacheDir
 		}
+		if xmlCacheDir != "" {
+			if err := os.MkdirAll(xmlCacheDir, 0755); err != nil {
+				log.Warnf("Failed to create XML cache directory: %v", err)
+				xmlCacheDir = ""
+			}
+		}
+	} else {
+		log.Debugf("Bypassing RPM primary location cache in live-installer mode")
 	}
 	if xmlCacheDir != "" {
 		primaryLocationCacheFile := filepath.Join(xmlCacheDir, "primary.location.json")

--- a/internal/utils/system/system.go
+++ b/internal/utils/system/system.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/logger"
@@ -107,6 +108,22 @@ func GetHostOsPkgManager() (string, error) {
 
 func GetProviderId(os, dist, arch string) string {
 	return os + "-" + dist + "-" + arch
+}
+
+// IsLiveInstallerExecution returns true when the current process is live-installer.
+// It checks the executable name and supports an env override for tests/tooling.
+func IsLiveInstallerExecution() bool {
+	mode := strings.TrimSpace(os.Getenv("ICT_EXECUTION_MODE"))
+	if strings.EqualFold(mode, "live-installer") {
+		return true
+	}
+
+	if len(os.Args) == 0 {
+		return false
+	}
+
+	exe := strings.ToLower(filepath.Base(strings.TrimSpace(os.Args[0])))
+	return strings.Contains(exe, "live-installer")
 }
 
 func StopGPGComponents(chrootPath string) error {


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->
This PR adjusts Debian repository metadata caching in internal/ospackage/debutils to avoid stale/incorrect parsed-metadata reuse when repositories are served from a loopback address (e.g., temporary local repositories), addressing a “localrepo offline cache conflict” scenario.

Changes:

Add loopback detection (localhost, 127.0.0.1, ::1) to decide when to bypass the parsed package metadata cache.
Gate both loading and saving of packages.parsed.json behind the new allowParsedCache flag to prevent reuse for loopback repositories.

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->