### PR TITLE
docs(architecture): add ADR for template extends

### DIFF
--- a/docs/architecture/adr-template-extends.md
+++ b/docs/architecture/adr-template-extends.md
@@ -76,16 +76,18 @@ systemConfig:
 ```mermaid
 flowchart TD
     A[Load child template] --> B{Has extends?}
-    B -- No --> G[Load OS default template]
+
+    B -- No --> G1[Load OS default template]
+    G1 --> I["Merge: MergeConfigurations(child, default) → final"]
+
     B -- Yes --> C[Resolve path relative to child location]
     C --> D[Load parent template]
     D --> E{Parent has extends?}
     E -- Yes --> ERR1[❌ Reject: single-level only]
     E -- No --> F{Target matches child?}
     F -- No --> ERR2["❌ Reject: target mismatch (OS/dist/arch/imageType)"]
-    F -- Yes --> G
-    G --> H["Merge 1: MergeConfigurations(parent, default) → intermediate"]
-    G -- No parent --> I["Merge: MergeConfigurations(child, default) → final"]
+    F -- Yes --> G2[Load OS default template]
+    G2 --> H["Merge 1: MergeConfigurations(parent, default) → intermediate"]
     H --> J["Merge 2: MergeConfigurations(child, intermediate) → final"]
 
     style ERR1 fill:#f44,color:#fff
@@ -112,7 +114,7 @@ The existing `MergeConfigurations()` is called twice. No changes to merge strate
 - **Single level only**: if the parent template contains `extends`, reject with a clear error
 - **Circular reference**: child cannot extend itself
 - **Target match**: child's `target` must match parent's `target` (prevents nonsensical cross-OS inheritance)
-- **Path safety**: resolve paths with `filepath.Clean`, reject symlinks (existing `security.RejectSymlinks`), prevent traversal outside workspace
+- **Path safety**: resolve paths with `filepath.Clean`, reject symlinks (existing `security.RejectSymlinks`), reject resolved paths that escape the child template's directory (i.e., disallow `../../../etc/` style traversal after cleaning)
 - **Schema**: `extends` added as optional string to `UserTemplate` schema; stripped from merged result
 
 ### Changes Required

--- a/docs/architecture/adr-template-extends.md
+++ b/docs/architecture/adr-template-extends.md
@@ -123,8 +123,22 @@ The existing `MergeConfigurations()` is called twice. No changes to merge strate
 | JSON schema | Add `extends` to `UserTemplate` definition |
 | `LoadAndMergeTemplate()` | Extend to handle 3-layer merge when `extends` is present |
 | `validate` command | Resolve `extends` chain during validation |
+| `build` command | No changes needed (already calls `LoadAndMergeTemplate`) |
+| CLI output | Log the resolved extends chain: `"Extending parent template: <path>"` |
+| `resolve` subcommand (new) | Dump the fully-merged template to stdout for debugging/traceability |
 | Tests | Basic extends, missing parent, chained rejection, target mismatch, circular ref, path traversal |
-| Documentation | Template docs, examples |
+| Documentation | Template docs, CLI specification, examples |
+
+### CLI/UX Changes
+
+- **`build`**: When `extends` is used, log the parent template path at info level so users can see the inheritance chain in build output
+- **`validate`**: Resolve the `extends` reference and validate the full merged result, not just the child template in isolation
+- **`resolve` (new subcommand)**: Output the fully-merged template as YAML to stdout. Works for all templates, not just ones using `extends`. For a standard template it shows the OS defaults + user merge result; with `extends` it shows OS defaults + parent + child. This replaces the need to read debug logs to see the merged configuration. Usage: `image-composer-tool resolve -t my-template.yml`
+- **Error messages**: Provide clear, actionable messages for common errors:
+  - `"template X extends Y, which also extends Z: only single-level extends is supported"`
+  - `"extends target mismatch: child targets ubuntu/x86_64 but parent targets azure-linux/x86_64"`
+  - `"circular extends: template X extends itself"`
+  - `"extends path not found: <resolved-path>"`
 
 ---
 

--- a/docs/architecture/adr-template-extends.md
+++ b/docs/architecture/adr-template-extends.md
@@ -163,6 +163,11 @@ The existing `MergeConfigurations()` is called twice. No changes to merge strate
 
 ### Alternatives Considered
 
-- **Multi-level extends (3-4 levels)**: Rejected due to significant increase in merge conflict resolution, debugging difficulty, and ordering ambiguity for order-sensitive sections
+- **Multi-level extends (3-4 levels)**: Rejected due to complexity that grows with each additional level:
+  - **Order-sensitive sections become ambiguous**: `configurations` contains shell commands appended in order. With A extends B extends C, the execution order across files is hard to predict and debug
+  - **Last-writer-wins conflicts**: for merge-by-key sections (`users`, `packageRepositories`), each level can silently override the previous. Users must trace the full chain to predict the outcome
+  - **No subtraction for additive sections**: packages are merged as a union. If an intermediate level adds a package, no downstream level can remove it without introducing a `remove`/`exclude` concept
+  - **Validation requires full chain resolution**: intermediate templates may be intentionally incomplete. Errors must point to the correct file and level, requiring provenance tracking through every merge step
+  - **Cycle and diamond detection**: multi-level chaining requires full graph cycle detection (A extends B extends C extends A), unlike single-level where checking if the parent has `extends` is sufficient
 - **Template fragments/mixins (`includes: [...]`)**: Different pattern that solves horizontal reuse but not the parent-child inheritance use case
 - **External pre-processing (yq, scripts)**: Already used by some users but pushes complexity outward and loses ICT validation/traceability

--- a/docs/architecture/adr-template-extends.md
+++ b/docs/architecture/adr-template-extends.md
@@ -1,7 +1,8 @@
-# ADR: Single-Level Template Extends
+# ADR: Template Extends
 
 **Status**: Proposed  
 **Date**: 2026-05-26  
+**Updated**: 2026-05-30  
 **Authors**: ICT Team  
 **Technical Area**: Template Configuration / Merge System
 
@@ -9,7 +10,7 @@
 
 ## Summary
 
-Add an optional `extends` field to user templates, enabling single-level inheritance from a parent template. This allows users to maintain a minimal delta template that automatically inherits updates from the parent template.
+Add an optional `extends` field to user templates, enabling linear inheritance chains. Each template may extend at most one parent template. The merge is applied iteratively from the root of the chain through each level, producing a deterministic result. This allows users to maintain minimal delta templates that automatically inherit updates from their parent templates.
 
 ---
 
@@ -25,17 +26,21 @@ ICT already implements a two-layer merge: OS-level default templates (`config/os
 
 ### Industry Precedent
 
-Docker Compose, ESLint, and Spring Boot all use `extends` for single-level parent-child template inheritance with field-level overrides, the same semantics proposed here.
+Docker Compose, ESLint, and Spring Boot all use `extends` for parent-child template inheritance with field-level overrides, the same semantics proposed here.
+
+### Key Design Constraint
+
+Each template may extend **at most one** parent (single inheritance). This prevents diamond/multiple-inheritance problems entirely. With this constraint, the extends chain is always a simple linear sequence, and `MergeConfigurations()` can be applied iteratively as a fold operation: if the merge is deterministic for 2 layers, it is deterministic for N.
 
 ---
 
 ## Decision
 
-Add an optional `extends` field to user templates, limited to a single level of inheritance.
+Add an optional `extends` field to user templates, supporting linear inheritance chains. Each template may extend at most one parent, and chains may be multiple levels deep.
 
 ### Template Example
 
-**Parent template** (`ubuntu24-x86_64-edge-raw.yml`):
+**Root template** (`ubuntu24-x86_64-edge-raw.yml`):
 ```yaml
 image:
   name: ubuntu24-x86_64-edge
@@ -54,9 +59,22 @@ systemConfig:
     version: "6.8.0-49-generic"
 ```
 
-**Child template** (`my-custom-edge.yml`):
+**Level 1 template** (`monitoring-edge.yml`) extends the root:
 ```yaml
 extends: "ubuntu24-x86_64-edge-raw.yml"
+
+image:
+  name: monitoring-edge
+
+systemConfig:
+  packages:
+    - prometheus-node-exporter
+    - grafana-agent
+```
+
+**Level 2 template** (`my-custom-edge.yml`) extends level 1:
+```yaml
+extends: "monitoring-edge.yml"
 
 image:
   name: my-custom-edge
@@ -64,56 +82,60 @@ image:
 systemConfig:
   packages:
     - my-custom-app
-    - monitoring-agent
   kernel:
     version: "6.8.0-50-generic"
 ```
 
-**Resolved merge** (3 layers): OS defaults → ubuntu24-x86_64-edge-raw.yml → my-custom-edge.yml
+**Resolved chain** (4 layers): OS defaults -> ubuntu24-x86_64-edge-raw.yml -> monitoring-edge.yml -> my-custom-edge.yml
+
+The final merged template contains packages from all levels: `docker-cli`, `containerd`, `openssh-server`, `prometheus-node-exporter`, `grafana-agent`, `my-custom-app` (deduplicated union). The kernel version is `6.8.0-50-generic` (last non-empty wins).
 
 ### Merge Flow
 
 ```mermaid
 flowchart TD
-    A[Load child template] --> B{Has extends?}
-
-    B -- No --> G1[Load OS default template]
-    G1 --> I["Merge: MergeConfigurations(child, default) → final"]
-
-    B -- Yes --> C[Resolve path relative to child location]
-    C --> D[Load parent template]
-    D --> E{Parent has extends?}
-    E -- Yes --> ERR1[❌ Reject: single-level only]
-    E -- No --> F{Target matches child?}
-    F -- No --> ERR2["❌ Reject: target mismatch (OS/dist/arch/imageType)"]
-    F -- Yes --> G2[Load OS default template]
-    G2 --> H["Merge 1: MergeConfigurations(parent, default) → intermediate"]
-    H --> J["Merge 2: MergeConfigurations(child, intermediate) → final"]
+    A[Load leaf template] --> B[Walk extends chain to find root]
+    B --> C{Cycle detected?}
+    C -- Yes --> ERR1["Reject: circular extends detected"]
+    C -- No --> D{All targets match?}
+    D -- No --> ERR2["Reject: target mismatch in chain"]
+    D -- Yes --> E[Load OS default template]
+    E --> F["Start: merged = MergeConfigurations(root, default)"]
+    F --> G{More levels in chain?}
+    G -- Yes --> H["merged = MergeConfigurations(next child, merged)"]
+    H --> G
+    G -- No --> I[Final merged template]
 
     style ERR1 fill:#f44,color:#fff
     style ERR2 fill:#f44,color:#fff
-    style J fill:#4a4,color:#fff
     style I fill:#4a4,color:#fff
 ```
 
-The existing `MergeConfigurations()` is called twice. No changes to merge strategies are needed; they compose naturally for two invocations.
+The algorithm walks the `extends` chain to collect all templates from leaf to root, then iteratively applies `MergeConfigurations()` starting from the root. This is a simple fold/reduce: `fold(MergeConfigurations, default, [root, level1, level2, ..., leaf])`. Since `MergeConfigurations` is deterministic for two inputs, the result is deterministic for any chain length.
 
 ### Merge Strategies (unchanged)
 
-| Section | Strategy | 3-layer behavior |
+Each strategy is applied iteratively at each level of the chain. The behavior is the same regardless of chain depth.
+
+| Section | Strategy | N-layer behavior |
 |---------|----------|-----------------|
-| `packages` | Additive (deduplicated) | defaults ∪ parent ∪ child |
-| `configurations` | Additive (append) | defaults, then parent, then child |
-| `users` | Merge by `name` | Field-level override across all 3 layers |
-| `disk` | Full replace | Last non-empty wins (child > parent > default) |
+| `packages` | Additive (deduplicated) | Union across all levels |
+| `configurations` | Additive (append) | Appended in chain order: root first, leaf last |
+| `users` | Merge by `name` | Field-level override; last level in chain wins per field |
+| `disk` | Full replace | Last non-empty wins |
 | `kernel` | Field-level override | Last non-empty field wins |
 | `packageRepositories` | Merge by `codename` | Last codename match wins |
 
+### Future Consideration: Partition Merge Granularity
+
+The current `disk` strategy replaces the entire disk configuration if any level provides one. An alternative approach is to merge `partitions` by partition ID (analogous to how packages are deduplicated by name), allowing a child template to override a single partition entry (e.g., resize `root`) without re-specifying the entire partition table. This is orthogonal to `extends` and could be addressed separately.
+
 ### Validation Rules
 
-- **Single level only**: if the parent template contains `extends`, reject with a clear error
-- **Circular reference**: child cannot extend itself
-- **Target match**: child's `target` must match parent's `target` (prevents nonsensical cross-OS inheritance)
+- **Single extends per template**: each template may reference at most one parent via `extends` (no multiple inheritance, no diamond problem)
+- **Cycle detection**: maintain a visited set while walking the chain; reject if any template appears twice (e.g., A extends B extends A)
+- **Target match**: all templates in the chain must have compatible `target` (OS/dist/arch/imageType); mismatch at any level is rejected
+- **Depth warning**: emit a warning when the chain exceeds 4 levels (OS default + 4 extends levels) to encourage maintainable hierarchies. No hard cap enforced
 - **Path safety**: resolve paths with `filepath.Clean`, reject symlinks (existing `security.RejectSymlinks`), reject resolved paths that escape the child template's directory (i.e., disallow `../../../etc/` style traversal after cleaning)
 - **Schema**: `extends` added as optional string to `UserTemplate` schema; stripped from merged result
 
@@ -123,24 +145,24 @@ The existing `MergeConfigurations()` is called twice. No changes to merge strate
 |-----------|--------|
 | `ImageTemplate` struct | Add `Extends string` field |
 | JSON schema | Add `extends` to `UserTemplate` definition |
-| `LoadAndMergeTemplate()` | Extend to handle 3-layer merge when `extends` is present |
-| `validate` command | Resolve `extends` chain during validation |
+| `LoadAndMergeTemplate()` | Walk extends chain, load all templates, iteratively apply `MergeConfigurations` |
+| `validate` command | Resolve full extends chain during validation |
 | `build` command | No changes needed (already calls `LoadAndMergeTemplate`) |
-| CLI output | Log the resolved extends chain: `"Extending parent template: <path>"` |
-| `resolve` subcommand (new) | Show the resolved parent + child merge when `extends` is used |
-| Tests | Basic extends, missing parent, chained rejection, target mismatch, circular ref, path traversal |
+| CLI output | Log the full resolved chain: `"Extends chain: root.yml -> level1.yml -> leaf.yml"` |
+| `resolve` subcommand (new) | Show the resolved extends chain merge (does not include OS defaults) |
+| Tests | Basic extends, multi-level chain, missing parent, cycle detection, target mismatch, depth warning, path traversal |
 | Documentation | Template docs, CLI specification, examples |
 
 ### CLI/UX Changes
 
-- **`build`**: When `extends` is used, log the parent template path at info level so users can see the inheritance chain in build output
-- **`validate`**: Resolve the `extends` reference and validate the full merged result, not just the child template in isolation
-- **`resolve` (new subcommand)**: When the template uses `extends`, output the resolved parent + child merged template as YAML to stdout (does not include OS defaults). If the template does not use `extends`, output the template as-is with a message: `"No extends used in template, nothing to resolve"`. Usage: `image-composer-tool resolve -t my-template.yml`
+- **`build`**: Log the full extends chain at info level so users can see the inheritance hierarchy in build output
+- **`validate`**: Resolve the full `extends` chain and validate the merged result
+- **`resolve` (new subcommand)**: When the template uses `extends`, output the resolved chain-merged template as YAML to stdout (does not include OS defaults). If the template does not use `extends`, output the template as-is with a message: `"No extends used in template, nothing to resolve"`. The `--full` flag includes OS defaults in the output, showing exactly what will be built. Usage: `image-composer-tool resolve -t my-template.yml [--full]`. Note: `resolve` always runs on-demand against current template files; output is never cached
 - **Error messages**: Provide clear, actionable messages for common errors:
-  - `"template X extends Y, which also extends Z: only single-level extends is supported"`
-  - `"extends target mismatch: child targets ubuntu/x86_64 but parent targets azure-linux/x86_64"`
-  - `"circular extends: template X extends itself"`
+  - `"circular extends detected: A -> B -> A"`
+  - `"extends target mismatch at level 2: child targets ubuntu/x86_64 but parent targets azure-linux/x86_64"`
   - `"extends path not found: <resolved-path>"`
+  - `"extends chain depth 5 exceeds recommended maximum of 4"` (warning, not error)
 
 ---
 
@@ -149,25 +171,28 @@ The existing `MergeConfigurations()` is called twice. No changes to merge strate
 ### Benefits
 
 - Users maintain only their delta, avoiding full-template copies that drift
-- Parent template updates (packages, security fixes) propagate automatically
-- No changes to existing merge logic; `MergeConfigurations` is reused as-is
-- Single-level restriction keeps debugging tractable: at most 3 places to check (OS default, parent, child)
+- Parent template updates (packages, security fixes) propagate automatically to all descendants
+- No changes to existing merge logic; `MergeConfigurations` is reused as a fold operation
+- Single-extends-per-template constraint prevents diamond/multiple-inheritance problems entirely
+- `resolve` subcommand provides full traceability regardless of chain depth
 
 ### Risks and Mitigations
 
 | Risk | Mitigation |
 |------|-----------|
-| Parent template breaking changes affect children silently | Document that parent templates are a contract; recommend versioning templates |
-| Users request multi-level extends | Single-level restriction is enforced at load time; can be revisited if demand is demonstrated |
+| Deep chains make debugging harder | `resolve` command shows fully merged result with chain info; depth warning at 4+ levels |
+| Parent template breaking changes affect descendants silently | Document that parent templates are a contract; recommend versioning templates |
+| Stale `resolve` output if base template changes | `resolve` always runs on-demand against current files; never cached |
 | Path resolution complexity (remote URLs, registries) | Start with local file paths only; remote support can be added later |
+
+### Why Multi-Level Linear Chaining Works
+
+- `MergeConfigurations(child, parent)` is a **pure function of two inputs**. Applying it iteratively (fold/reduce) produces deterministic results at any depth
+- With **single extends per template**, the chain is always linear. There is no diamond problem, no multiple inheritance, and cycle detection is a simple visited-set check
+- **Order of merge is well-defined**: OS defaults -> root -> level 1 -> ... -> leaf. For additive sections (`packages`, `configurations`), items accumulate in chain order. For override sections (`kernel`, `disk`), last non-empty wins. Both are predictable
+- Concerns around ambiguous ordering, last-writer-wins confusion, and validation complexity apply primarily to **multiple inheritance** (extending from more than one parent), not to linear chaining
 
 ### Alternatives Considered
 
-- **Multi-level extends (3-4 levels)**: Rejected due to complexity that grows with each additional level:
-  - **Order-sensitive sections become ambiguous**: `configurations` contains shell commands appended in order. With A extends B extends C, the execution order across files is hard to predict and debug
-  - **Last-writer-wins conflicts**: for merge-by-key sections (`users`, `packageRepositories`), each level can silently override the previous. Users must trace the full chain to predict the outcome
-  - **No subtraction for additive sections**: packages are merged as a union. If an intermediate level adds a package, no downstream level can remove it without introducing a `remove`/`exclude` concept
-  - **Validation requires full chain resolution**: intermediate templates may be intentionally incomplete. Errors must point to the correct file and level, requiring provenance tracking through every merge step
-  - **Cycle and diamond detection**: multi-level chaining requires full graph cycle detection (A extends B extends C extends A), unlike single-level where checking if the parent has `extends` is sufficient
-- **Template fragments/mixins (`includes: [...]`)**: Different pattern that solves horizontal reuse but not the parent-child inheritance use case
+- **Multiple inheritance (`extends: [a.yml, b.yml]`)**: Rejected. Introduces diamond problem, ambiguous merge ordering between siblings, and significantly more complex conflict resolution
 - **External pre-processing (yq, scripts)**: Already used by some users but pushes complexity outward and loses ICT validation/traceability

--- a/docs/architecture/adr-template-extends.md
+++ b/docs/architecture/adr-template-extends.md
@@ -1,0 +1,152 @@
+# ADR: Single-Level Template Extends
+
+**Status**: Proposed  
+**Date**: 2026-05-26  
+**Authors**: ICT Team  
+**Technical Area**: Template Configuration / Merge System
+
+---
+
+## Summary
+
+Add an optional `extends` field to user templates, enabling single-level inheritance from a parent template. This allows users to maintain a minimal delta template that automatically inherits updates from the parent template.
+
+---
+
+## Context
+
+### Problem Statement
+
+Teams often publish reusable templates (e.g., `ubuntu24-x86_64-edge-raw.yml`) that define a baseline image configuration. Other users need to customize these for specific use cases, typically adding packages or changing the kernel. Today, they must copy the entire template and modify it. When the original template is updated (security patches, new default packages), every copy must be manually re-synchronized.
+
+### Current System
+
+ICT already implements a two-layer merge: OS-level default templates (`config/osv/`) are merged with the user template at build time, using well-defined per-attribute strategies (additive, override, replace, merge-by-key). This works well for OS-to-user inheritance but does not support template-to-template inheritance.
+
+### Industry Precedent
+
+Docker Compose, ESLint, and Spring Boot all use `extends` for single-level parent-child template inheritance with field-level overrides, the same semantics proposed here.
+
+---
+
+## Decision
+
+Add an optional `extends` field to user templates, limited to a single level of inheritance.
+
+### Template Example
+
+**Parent template** (`ubuntu24-x86_64-edge-raw.yml`):
+```yaml
+image:
+  name: ubuntu24-x86_64-edge
+  version: "1.0.0"
+target:
+  os: ubuntu
+  dist: ubuntu24
+  arch: x86_64
+  imageType: raw
+systemConfig:
+  packages:
+    - docker-cli
+    - containerd
+    - openssh-server
+  kernel:
+    version: "6.8.0-49-generic"
+```
+
+**Child template** (`my-custom-edge.yml`):
+```yaml
+extends: "ubuntu24-x86_64-edge-raw.yml"
+
+image:
+  name: my-custom-edge
+
+systemConfig:
+  packages:
+    - my-custom-app
+    - monitoring-agent
+  kernel:
+    version: "6.8.0-50-generic"
+```
+
+**Resolved merge** (3 layers): OS defaults → ubuntu24-x86_64-edge-raw.yml → my-custom-edge.yml
+
+### Merge Flow
+
+```mermaid
+flowchart TD
+    A[Load child template] --> B{Has extends?}
+    B -- No --> G[Load OS default template]
+    B -- Yes --> C[Resolve path relative to child location]
+    C --> D[Load parent template]
+    D --> E{Parent has extends?}
+    E -- Yes --> ERR1[❌ Reject: single-level only]
+    E -- No --> F{Target matches child?}
+    F -- No --> ERR2["❌ Reject: target mismatch (OS/dist/arch/imageType)"]
+    F -- Yes --> G
+    G --> H["Merge 1: MergeConfigurations(parent, default) → intermediate"]
+    G -- No parent --> I["Merge: MergeConfigurations(child, default) → final"]
+    H --> J["Merge 2: MergeConfigurations(child, intermediate) → final"]
+
+    style ERR1 fill:#f44,color:#fff
+    style ERR2 fill:#f44,color:#fff
+    style J fill:#4a4,color:#fff
+    style I fill:#4a4,color:#fff
+```
+
+The existing `MergeConfigurations()` is called twice. No changes to merge strategies are needed; they compose naturally for two invocations.
+
+### Merge Strategies (unchanged)
+
+| Section | Strategy | 3-layer behavior |
+|---------|----------|-----------------|
+| `packages` | Additive (deduplicated) | defaults ∪ parent ∪ child |
+| `configurations` | Additive (append) | defaults, then parent, then child |
+| `users` | Merge by `name` | Field-level override across all 3 layers |
+| `disk` | Full replace | Last non-empty wins (child > parent > default) |
+| `kernel` | Field-level override | Last non-empty field wins |
+| `packageRepositories` | Merge by `codename` | Last codename match wins |
+
+### Validation Rules
+
+- **Single level only**: if the parent template contains `extends`, reject with a clear error
+- **Circular reference**: child cannot extend itself
+- **Target match**: child's `target` must match parent's `target` (prevents nonsensical cross-OS inheritance)
+- **Path safety**: resolve paths with `filepath.Clean`, reject symlinks (existing `security.RejectSymlinks`), prevent traversal outside workspace
+- **Schema**: `extends` added as optional string to `UserTemplate` schema; stripped from merged result
+
+### Changes Required
+
+| Component | Change |
+|-----------|--------|
+| `ImageTemplate` struct | Add `Extends string` field |
+| JSON schema | Add `extends` to `UserTemplate` definition |
+| `LoadAndMergeTemplate()` | Extend to handle 3-layer merge when `extends` is present |
+| `validate` command | Resolve `extends` chain during validation |
+| Tests | Basic extends, missing parent, chained rejection, target mismatch, circular ref, path traversal |
+| Documentation | Template docs, examples |
+
+---
+
+## Consequences
+
+### Benefits
+
+- Users maintain only their delta, avoiding full-template copies that drift
+- Parent template updates (packages, security fixes) propagate automatically
+- No changes to existing merge logic; `MergeConfigurations` is reused as-is
+- Single-level restriction keeps debugging tractable: at most 3 places to check (OS default, parent, child)
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Parent template breaking changes affect children silently | Document that parent templates are a contract; recommend versioning templates |
+| Users request multi-level extends | Single-level restriction is enforced at load time; can be revisited if demand is demonstrated |
+| Path resolution complexity (remote URLs, registries) | Start with local file paths only; remote support can be added later |
+
+### Alternatives Considered
+
+- **Multi-level extends (3-4 levels)**: Rejected due to significant increase in merge conflict resolution, debugging difficulty, and ordering ambiguity for order-sensitive sections
+- **Template fragments/mixins (`includes: [...]`)**: Different pattern that solves horizontal reuse but not the parent-child inheritance use case
+- **External pre-processing (yq, scripts)**: Already used by some users but pushes complexity outward and loses ICT validation/traceability

--- a/docs/architecture/adr-template-extends.md
+++ b/docs/architecture/adr-template-extends.md
@@ -127,7 +127,7 @@ The existing `MergeConfigurations()` is called twice. No changes to merge strate
 | `validate` command | Resolve `extends` chain during validation |
 | `build` command | No changes needed (already calls `LoadAndMergeTemplate`) |
 | CLI output | Log the resolved extends chain: `"Extending parent template: <path>"` |
-| `resolve` subcommand (new) | Dump the fully-merged template to stdout for debugging/traceability |
+| `resolve` subcommand (new) | Show the resolved parent + child merge when `extends` is used |
 | Tests | Basic extends, missing parent, chained rejection, target mismatch, circular ref, path traversal |
 | Documentation | Template docs, CLI specification, examples |
 
@@ -135,7 +135,7 @@ The existing `MergeConfigurations()` is called twice. No changes to merge strate
 
 - **`build`**: When `extends` is used, log the parent template path at info level so users can see the inheritance chain in build output
 - **`validate`**: Resolve the `extends` reference and validate the full merged result, not just the child template in isolation
-- **`resolve` (new subcommand)**: Output the fully-merged template as YAML to stdout. Works for all templates, not just ones using `extends`. For a standard template it shows the OS defaults + user merge result; with `extends` it shows OS defaults + parent + child. This replaces the need to read debug logs to see the merged configuration. Usage: `image-composer-tool resolve -t my-template.yml`
+- **`resolve` (new subcommand)**: When the template uses `extends`, output the resolved parent + child merged template as YAML to stdout (does not include OS defaults). If the template does not use `extends`, output the template as-is with a message: `"No extends used in template, nothing to resolve"`. Usage: `image-composer-tool resolve -t my-template.yml`
 - **Error messages**: Provide clear, actionable messages for common errors:
   - `"template X extends Y, which also extends Z: only single-level extends is supported"`
   - `"extends target mismatch: child targets ubuntu/x86_64 but parent targets azure-linux/x86_64"`


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [ ] Ready to merge

#### Description <!-- REQUIRED -->

Adds an Architecture Decision Record (ADR) proposing `extends` support for image templates.

**Problem:** Users who need to customize existing templates must copy the entire template and modify it. When the original template is updated, every copy must be manually re-synchronized.

**Proposal:** Add an optional `extends` field to user templates that enables linear inheritance chains. Each template may extend at most one parent (single inheritance, no diamond problem). The merge is applied iteratively using the existing `MergeConfigurations()` as a fold operation, producing deterministic results at any chain depth.

Key design decisions:
- Reuses existing `MergeConfigurations()` applied iteratively (OS defaults -> root -> level 1 -> ... -> leaf)
- Single extends per template (no multiple inheritance) keeps merge deterministic
- Cycle detection via visited-set check
- Validation for target mismatches across the chain
- Depth warning at 4+ levels (soft limit, no hard cap)
- New `resolve` subcommand to inspect the merged result
- Local file paths only (no remote URL support initially)

#### Any Newly Introduced Dependencies

None. This is a documentation-only change.

#### How Has This Been Tested? <!-- REQUIRED -->

Documentation-only change. No code changes to test.