### PR TITLE
fix(templates): update ubuntu26 minimal-raw kernel to 7.0

### DIFF
--- a/config/osv/ubuntu/ubuntu26/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
+++ b/config/osv/ubuntu/ubuntu26/imageconfigs/defaultconfigs/default-initrd-x86_64.yml
@@ -64,7 +64,7 @@ systemConfig:
 
   kernel:
     name: kernel
-    version: "6.17"
+    version: "7.0"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
       - linux-image-generic

--- a/config/osv/ubuntu/ubuntu26/imageconfigs/defaultconfigs/default-raw-aarch64.yml
+++ b/config/osv/ubuntu/ubuntu26/imageconfigs/defaultconfigs/default-raw-aarch64.yml
@@ -68,7 +68,7 @@ systemConfig:
       final: /etc/apt/sources.list.d/ubuntu-resolute.list
 
   kernel:
-    version: "6.17"
+    version: "7.0"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
       - linux-image-generic

--- a/config/osv/ubuntu/ubuntu26/imageconfigs/defaultconfigs/default-raw-x86_64.yml
+++ b/config/osv/ubuntu/ubuntu26/imageconfigs/defaultconfigs/default-raw-x86_64.yml
@@ -78,7 +78,7 @@ systemConfig:
       final: /etc/apt/sources.list.d/ubuntu-resolute.list
 
   kernel:
-    version: "6.17"
+    version: "7.0"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
       - linux-image-generic

--- a/image-templates/ubuntu26-x86_64-minimal-raw.yml
+++ b/image-templates/ubuntu26-x86_64-minimal-raw.yml
@@ -82,7 +82,7 @@ systemConfig:
     - systemd-timesyncd
 
   kernel:
-    version: "6.17"
+    version: "7.0"
     cmdline: "console=ttyS0,115200 console=tty0 loglevel=7"
     packages:
       - linux-image-generic


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->

The Ubuntu 26.04 (`resolute`) archive now ships kernel **7.0**. The
`ubuntu26-x86_64-minimal-raw.yml` template still pinned `kernel.version`
to `"6.17"`, which caused image builds to fail at the package-resolution
stage with:

```
ERROR debutils/download.go:967 kernel version mismatch: requires kernel
version "6.17", but available versions are: [7.0.0-14.14 7.0.0-22.22]
Error: pre-processing failed: failed to download image packages
```

This PR updates `kernel.version` in
`image-templates/ubuntu26-x86_64-minimal-raw.yml` from `"6.17"` to
`"7.0"` so the template matches what is currently published in the
Ubuntu archive. The `linux-image-generic` meta-package name is unchanged.

No code, schema, CLI, or documented behavior is changed - only a single
data value in one example template - so no documentation update is
required.

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested?

Built and ran locally end-to-end against the live Ubuntu archive:

```
earthly +build
sudo ./build/image-composer-tool validate \
  image-templates/ubuntu26-x86_64-minimal-raw.yml
sudo ./build/image-composer-tool build \
  image-templates/ubuntu26-x86_64-minimal-raw.yml
```

Result: build completes successfully in ~4 minutes and produces:

- `minimal-os-image-ubuntu-26.04.raw.gz`
- `minimal-os-image-ubuntu-26.04.vhdx` (1.82 GB)
- `spdx_manifest_deb_minimal-os-image-ubuntu_*.json`

Stage timings:

| Stage | Duration |
|---|---|
| Initialization | 1.9s |
| Package Download | 16.4s |
| Chroot Package Download | 5.0s |
| Chroot Env Init | 44.1s |
| Image Build | 1m47s |
| Image Conversion | 1m3s |
| Finalization | 0.4s |
| **Total** | **3m58s** |
