### PR TITLE
docs(agents): Updated Copilot instructions and add scoped companion files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,7 @@
 
 ICT builds custom Linux images from pre-built packages. Key components:
 
-- **Provider** (`internal/provider/`) — Orchestrates builds per OS (azl, debian13, elxr, emt, rcd, ubuntu). Implements the `Provider` interface with `Name`, `Init`, `PreProcess`, `BuildImage`, `PostProcess`. Each provider exports an `OsName` constant and a `Register()` function.
+- **Provider** (`internal/provider/`) — Orchestrates builds per OS. Directory names are `azl`, `debian13`, `elxr`, `emt`, `rcd`, `ubuntu`; their `target.os` / `OsName` values are `azure-linux`, `debian`, `wind-river-elxr`, `edge-microvisor-toolkit`, `redhat-compatible-distro`, `ubuntu` (use these in templates). Implements the `Provider` interface with `Name`, `Init`, `PreProcess`, `BuildImage`, `PostProcess`. Each provider exports an `OsName` constant and a `Register()` function.
 - **Image makers** (`internal/image/`) — Output formats: `rawmaker/`, `isomaker/`, `initrdmaker/`.
 - **Chroot** (`internal/chroot/`) — Isolated build environments with package installers for `deb/` and `rpm/`.
 - **Config** (`internal/config/`) — Template loading, defaults+user merge, validation.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,20 +1,80 @@
 # Copilot Instructions for image-composer-tool
 
+> These instructions are loaded into every Copilot Chat / agent session in this repo.
+> Keep them **concise, current, and actionable**. Move detail to `docs/` or to scoped
+> `.github/instructions/*.instructions.md` files (see [Companion customization files](#companion-customization-files)).
+
+---
+
+## TL;DR for agents (read this first)
+
+1. **Plan, then act.** For any task with >1 step, create a `manage_todo_list` plan, mark items in-progress/completed as you go.
+2. **Gather context efficiently.** Parallelize independent reads/searches. Read large ranges in one call. Stop searching once you can act.
+3. **Implement, don't just suggest.** Default to making the change. Use the smallest diff that solves the problem.
+4. **Verify after every edit.** Run `get_errors` on touched files; run `earthly +test-quick` (or `go test ./...`) and `earthly +lint` (or `golangci-lint run`) before declaring done.
+5. **Match existing patterns.** Project logger (not `fmt.Println`), `network.GetSecureHTTPClient()` (not `http.DefaultClient`), `internal/utils/shell` (not raw `exec.Command`), `filepath.Clean` on user paths.
+6. **Stay in scope.** No drive-by refactors, no new comments/docstrings on code you didn't change, no new abstractions for one-off use.
+7. **Update docs in the same PR** when behavior changes (see [Documentation](#documentation)).
+8. **Never bypass safety gates.** No `--no-verify`, no `git push --force`, no skipping tests. Confirm with the user before destructive or shared-system actions.
+
+---
+
 ## Architecture Overview
 
 ICT builds custom Linux images from pre-built packages. Key components:
 
-- **Provider** (`internal/provider/`) - Orchestrates builds per OS (azl, elxr, emt, rcd, ubuntu). Implements `Provider` interface with `Name`, `Init`, `PreProcess`, `BuildImage`, `PostProcess` methods. Each provider exports an `OsName` constant and a `Register()` function
-- **Image makers** (`internal/image/`) - Creates output formats: `rawmaker/`, `isomaker/`, `initrdmaker/`
-- **Chroot** (`internal/chroot/`) - Isolated build environments with package installers for `deb/` and `rpm/`
-- **Config** (`internal/config/`) - Template loading, merging defaults with user templates, validation
-- **OsPackage** (`internal/ospackage/`) - Package utilities: `debutils/`, `rpmutils/` for dependency resolution
+- **Provider** (`internal/provider/`) — Orchestrates builds per OS (azl, debian13, elxr, emt, rcd, ubuntu). Implements the `Provider` interface with `Name`, `Init`, `PreProcess`, `BuildImage`, `PostProcess`. Each provider exports an `OsName` constant and a `Register()` function.
+- **Image makers** (`internal/image/`) — Output formats: `rawmaker/`, `isomaker/`, `initrdmaker/`.
+- **Chroot** (`internal/chroot/`) — Isolated build environments with package installers for `deb/` and `rpm/`.
+- **Config** (`internal/config/`) — Template loading, defaults+user merge, validation.
+- **OsPackage** (`internal/ospackage/`) — Package utilities: `debutils/`, `rpmutils/` for dependency resolution.
 
-Data flow: CLI → Config loads template → Provider.Init → Provider.PreProcess (downloads packages) → Provider.BuildImage (creates chroot, installs packages, generates image) → Provider.PostProcess
+Data flow: CLI → Config loads template → `Provider.Init` → `Provider.PreProcess` (downloads packages) → `Provider.BuildImage` (creates chroot, installs packages, generates image) → `Provider.PostProcess`.
+
+---
+
+## Agent workflow rules
+
+These rules let the agent move fast without breaking things. They reflect 2025-era best practice for VS Code Copilot agent mode.
+
+### Context gathering
+- Prefer the workspace search/read tools over shelling out to `grep`/`find`/`cat`.
+- **Parallelize** independent read-only operations (`grep_search`, `read_file`, `file_search`) in a single tool batch.
+- Use the **Explore subagent** for broad codebase questions ("where is X used", "how does Y work") instead of chaining many searches in the main thread — it preserves your context budget.
+- Stop searching once you have enough to act. If overlapping queries return the same files, you're done.
+
+### Planning & progress
+- Use `manage_todo_list` for any multi-step task. Exactly one item `in-progress` at a time. Mark `completed` immediately on finish — do not batch.
+- Skip the todo list for trivial single-step changes.
+
+### Editing
+- Read a file before editing it. Use `multi_replace_string_in_file` when making several edits in one or more files in a single turn.
+- Include 3–5 lines of unchanged context before and after each replacement target so matches are unique.
+- **Never edit files by running shell commands** (`sed`, `awk`, heredoc redirects) unless the user explicitly asks.
+- For rename refactors, prefer `vscode_renameSymbol` over text replace — it's semantics-aware.
+
+### Verification loop
+After each meaningful edit:
+1. `get_errors` on the changed files.
+2. Run targeted tests for the affected package (e.g. `go test ./internal/provider/ubuntu/...`).
+3. Before handoff, run `earthly +test-quick` (or `go test ./...`) and `earthly +lint`.
+
+### Anti-patterns the agent should refuse
+- Adding `// TODO`, docstrings, or type annotations to code that wasn't otherwise changed.
+- Creating "helper" packages or interfaces for a single caller.
+- Catching errors only to re-throw them with no added context.
+- Pulling in new dependencies without a stated reason.
+- Generating new markdown "summary of changes" files unless requested — put that in the PR description instead.
+
+### Memory
+- Record durable repo facts (verified commands, gotchas, non-obvious conventions) under `/memories/repo/`. Consult before re-investigating something.
+- Use `/memories/session/` for in-progress task notes; do not pollute repo memory with one-off context.
+
+---
 
 ## Build and Test
 
-Always use **Earthly** for builds and testing when available. If Earthly is not configured in your environment, you can fall back to standard Go commands:
+Always use **Earthly** when available. Fallback to plain Go if Earthly is missing.
 
 | Task | Earthly (preferred) | Go fallback |
 |------|---------------------|-------------|
@@ -23,85 +83,93 @@ Always use **Earthly** for builds and testing when available. If Earthly is not 
 | Test (coverage) | `earthly +test` | `go test -coverprofile=coverage.out ./...` |
 | Lint | `earthly +lint` | `golangci-lint run` |
 
-Note: CI runs Earthly, so always verify with `earthly +test` and `earthly +lint` before opening a PR if possible, to avoid CI failures.
+CI runs Earthly, so verify with `earthly +test` and `earthly +lint` before opening a PR.
 
-Coverage threshold is enforced in CI and auto-ratcheted — see `.coverage-threshold` for the current value
+Coverage threshold is enforced and auto-ratcheted — see `.coverage-threshold`.
+
+---
 
 ## Adding a New OS Provider
 
-1. Create package in `internal/provider/{osname}/`
-2. Implement `provider.Provider` interface (see `internal/provider/provider.go`)
-3. Register in `cmd/image-composer-tool/build.go` switch statement
-4. Add default configs in `config/osv/{osname}/`
-5. Create example templates in `image-templates/`
+1. Create package in `internal/provider/{osname}/` implementing the `provider.Provider` interface (see [internal/provider/provider.go](../internal/provider/provider.go)).
+2. Register in the `switch` in `cmd/image-composer-tool/build.go`.
+3. Add default configs in `config/osv/{osname}/` and example templates in `image-templates/`.
+4. Add tests and update `docs/architecture/architecture.md`.
+
+> Full provider conventions + checklist: [.github/instructions/provider.instructions.md](instructions/provider.instructions.md) (auto-applies to `internal/provider/**/*.go`).
+> End-to-end scaffold prompt: [.github/prompts/add-os-provider.prompt.md](prompts/add-os-provider.prompt.md).
+
+---
 
 ## Testing Patterns
 
-- Use **stdlib `testing` only** — no testify or external assertion libraries
-- Use **table-driven tests** with `t.Run()` for multiple cases:
-```go
-tests := []struct{ name string; input string; want error }{...}
-for _, tt := range tests {
-    t.Run(tt.name, func(t *testing.T) { ... })
-}
-```
-- Follow the **AAA pattern**: Arrange (setup), Act (execute), Assert (verify)
-- Test file naming: `*_test.go` in same package
-- Reset shared state in tests (see `resetBuildFlags()` pattern in `cmd/image-composer-tool/build_test.go`)
+stdlib `testing` only (no testify), table-driven with `t.Run()`, AAA layout, `t.TempDir()` for filesystem, `t.Parallel()` where safe.
+
+> Full conventions: [.github/instructions/go-tests.instructions.md](instructions/go-tests.instructions.md) (auto-applies to `**/*_test.go`).
+
+---
 
 ## Error Handling
 
-- **Always wrap** with context: `fmt.Errorf("failed to X: %w", err)`
-- Use named returns with defer for cleanup (see `docs/architecture/image-composer-tool-coding-style.md`)
-- Never ignore errors with `_`
+- **Always wrap** with context: `fmt.Errorf("failed to X: %w", err)`.
+- Use **named returns + `defer`** for cleanup (see `docs/architecture/image-composer-tool-coding-style.md` §4.3).
+- Never ignore errors with `_` (caught by `errcheck`).
+- Validate inputs at system boundaries only — don't defensively re-validate internal callers.
+
+---
 
 ## Logging
 
-- Use the project logger, **not** `fmt.Println` or `log` stdlib:
-```go
-import "github.com/open-edge-platform/image-composer-tool/internal/utils/logger"
+- Use the project logger, **not** `fmt.Println` or the `log` stdlib:
+  ```go
+  import "github.com/open-edge-platform/image-composer-tool/internal/utils/logger"
 
-var log = logger.Logger()
-```
-- Every package that logs should declare `var log = logger.Logger()` at package level
+  var log = logger.Logger()
+  ```
+- Every logging package declares `var log = logger.Logger()` at package level.
 - **Three-layer logging strategy**:
-  - **Utilities** (`internal/utils/`): primarily return errors; use `log.Debugf()` sparingly
-  - **Business logic** (`internal/provider/`, `internal/config/`, etc.): log with business context (`log.Infof`, `log.Warnf`, `log.Errorf`) and return errors with technical context
-  - **Top-level orchestrators** (`cmd/`): only return errors — logging happens at lower levels
-- Available levels: `log.Debugf()`, `log.Infof()`, `log.Warnf()`, `log.Errorf()`
+  - **Utilities** (`internal/utils/`): primarily return errors; `log.Debugf()` sparingly.
+  - **Business logic** (`internal/provider/`, `internal/config/`, …): log business context (`log.Infof`, `log.Warnf`, `log.Errorf`) and return errors with technical context.
+  - **Top-level orchestrators** (`cmd/`): only return errors — logging happens below.
+- Levels: `log.Debugf()`, `log.Infof()`, `log.Warnf()`, `log.Errorf()`.
+
+---
 
 ## Code Style
 
-- **Line length**: 120 characters max
-- **Function length**: under 50 lines — break up larger functions
-- **Parameters**: max 4–5 per function; use a config/options struct beyond that
-- **Imports**: stdlib → third-party → local (blank line separated)
-- **Struct-based design over globals** — prefer dependency injection
-- **Interface naming**: should end with `-er` when possible (e.g., `PackageInstaller`, `ConfigReader`)
-- **Named returns + defer for cleanup** — the standard cleanup pattern (not "goto fail"); see [coding style Section 4.3](../docs/architecture/image-composer-tool-coding-style.md)
-- **Linters** (`earthly +lint`): `govet`, `gofmt`, `errcheck`, `staticcheck`, `unused`, `gosimple` — all errors must be handled (`errcheck` is enforced)
-- Shell scripts: `set -euo pipefail`
-- See `docs/architecture/image-composer-tool-coding-style.md` for the full guide
+- **Line length**: 120 chars max.
+- **Function length**: under 50 lines — split larger ones.
+- **Parameters**: max 4–5; use a config/options struct beyond that.
+- **Imports**: stdlib → third-party → local (blank-line separated).
+- **Struct-based design over globals** — prefer dependency injection.
+- **Interface naming**: end with `-er` (`PackageInstaller`, `ConfigReader`).
+- **Named returns + defer** for cleanup (the standard pattern; not "goto fail").
+- **Linters** (`earthly +lint`): `govet`, `gofmt`, `errcheck`, `staticcheck`, `unused`, `gosimple` — all errors must be handled.
+- Shell scripts: `set -euo pipefail`.
+- See `docs/architecture/image-composer-tool-coding-style.md` for the full guide.
+
+---
 
 ## Security
 
-- **HTTP clients**: Always use `network.NewSecureHTTPClient()` or the singleton `network.GetSecureHTTPClient()` from `internal/utils/network/` — enforces TLS 1.2+ with approved cipher suites. Never use `http.DefaultClient`
-- **Command execution**: Use the `internal/utils/shell/` package which maintains an allowlist of approved system commands. Never use raw `exec.Command()`
-- **Input validation**: Sanitize user-provided filenames and paths; use `filepath.Clean()` on paths
-- **Template validation**: Templates are validated against JSON schema (`os-image-template.schema.json`) via `image-composer-tool validate`
-- **File permissions**: `0700` for chroot dirs, `0755` for general dirs, `0644` for data files, `0640` for log files
-- CI runs **Trivy** (dependency vulnerability scanning — fails on HIGH/CRITICAL), **Gitleaks** (secret detection), and **Zizmor** (GitHub Actions security auditing)
+- **HTTP clients**: Always use `network.NewSecureHTTPClient()` or the singleton `network.GetSecureHTTPClient()` from `internal/utils/network/` — enforces TLS 1.2+ with approved cipher suites. **Never** use `http.DefaultClient`.
+- **Command execution**: Use `internal/utils/shell/` (allowlisted commands). **Never** use raw `exec.Command()`.
+- **Input validation**: Sanitize user-provided filenames/paths; always `filepath.Clean()` on paths derived from input.
+- **Template validation**: Templates are validated against `os-image-template.schema.json` via `image-composer-tool validate`.
+- **File permissions**: `0700` chroot dirs, `0755` general dirs, `0644` data files, `0640` log files.
+- **Secrets**: Never write tokens/keys to files or logs. Do not embed secrets in test fixtures.
+- CI runs **Trivy** (HIGH/CRITICAL fail), **Gitleaks** (secret detection), **Zizmor** (Actions auditing).
+
+---
 
 ## Documentation
 
-**Every PR that changes behavior must include corresponding documentation updates.** Documentation is a first-class deliverable — treat it as part of the code change, not an afterthought.
-
-Before opening a PR, check whether your changes affect any of these and update accordingly:
+**Every PR that changes behavior must include corresponding documentation updates.** Treat docs as part of the change, not an afterthought.
 
 | What changed | Docs to update |
 |---|---|
 | CLI flags or commands | `docs/architecture/image-composer-tool-cli-specification.md`, `docs/tutorial/usage-guide.md` |
-| Build process or Earthfile targets | `docs/tutorial/usage-guide.md`, this file's **Build and Test** section |
+| Build process / Earthfile targets | `docs/tutorial/usage-guide.md`, this file's **Build and Test** section |
 | Image template schema or fields | `docs/architecture/image-composer-tool-templates.md`, relevant `image-templates/*.yml` examples |
 | New OS provider | `docs/architecture/architecture.md`, this file's **Adding a New OS Provider** section |
 | New tutorial-worthy feature | Add or update a guide in `docs/tutorial/` |
@@ -112,44 +180,73 @@ Before opening a PR, check whether your changes affect any of these and update a
 | Dependencies or multi-repo setup | `docs/architecture/image-composer-tool-multi-repo-support.md` |
 | User-facing features or fixes | `docs/release-notes.md` |
 
+If no docs need updating, **say so explicitly in the PR description**.
+
+---
+
 ## Git Commits & PRs
 
-- Sign commits: `git commit -S`
-- Conventional commits: `type(scope): description` (feat, fix, docs, test, refactor, chore)
-- **Always use** `.github/PULL_REQUEST_TEMPLATE.md` for PRs
-- Branch prefixes: `feature/`, `fix/`, `docs/`, `refactor/`
-- **Always update documentation** alongside code changes (see **Documentation** section above). If no docs need updating, explicitly state so in the PR description
+- Sign commits: `git commit -S`.
+- **Conventional commits**: `type(scope): description` (`feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `build`, `ci`, `perf`).
+- Branch prefixes: `feature/`, `fix/`, `docs/`, `refactor/`.
+- **Use `.github/PULL_REQUEST_TEMPLATE.md`** for every PR.
+- **Do not** add AI co-author trailers (e.g. `Co-authored-by: Copilot …`) unless the repo explicitly asks for them.
+- **Do not** force-push to shared branches. Never use `--no-verify`.
+- Squash trivial fixup commits locally before pushing.
+- The `gh` CLI is available — use it for PR/issue interactions over manual web steps.
+
+---
 
 ## CI Quality Gates
 
-All PRs must pass these checks before merging:
+All PRs must pass before merge:
 
 | Gate | What it checks |
 |------|----------------|
 | Unit tests + coverage | `earthly +test` — threshold auto-ratchets via `.coverage-threshold` |
-| Lint | `earthly +lint` — golangci-lint with `govet`, `gofmt`, `errcheck`, `staticcheck`, `unused`, `gosimple` |
-| Trivy scan | Dependency vulnerabilities (HIGH/CRITICAL) + SBOM generation |
-| Gitleaks | Secret leak detection in commits |
-| Zizmor | GitHub Actions workflow security auditing |
+| Lint | `earthly +lint` — `govet`, `gofmt`, `errcheck`, `staticcheck`, `unused`, `gosimple` |
+| Trivy scan | Dependency vulns (HIGH/CRITICAL) + SBOM generation |
+| Gitleaks | Secret-leak detection |
+| Zizmor | GitHub Actions security auditing |
 | Integration builds | Per-OS/arch image builds |
+
+---
 
 ## Image Template Conventions
 
-- **Naming**: `<dist>-<arch>-<purpose>-<imageType>.yml` (e.g., `emt3-x86_64-minimal-raw.yml`)
-- **Minimal user templates**: only `image` + `target` sections required; OS defaults handle the rest
-- **Always include a `metadata` block** with `description`, `use_cases`, and `keywords` for discoverability
-- **Merge behavior**: packages are _additive_ (merged by name); `disk` configuration _replaces_ entirely
-- **Validate** before committing: `image-composer-tool validate -t <template.yml>`
+Name `<dist>-<arch>-<purpose>-<imageType>.yml`. Minimal user templates need only `image` + `target`; always include a `metadata` block. Packages merge _additively_; `disk` _replaces_ entirely. Validate with `image-composer-tool validate -t <template.yml>` before committing.
+
+> Full conventions: [.github/instructions/image-templates.instructions.md](instructions/image-templates.instructions.md) (auto-applies to `image-templates/**/*.yml`).
+
+---
+
+## Companion customization files
+
+This single file is loaded into every chat. Keep it lean — path-specific and workflow-specific guidance lives in scoped companions:
+
+- **`.github/instructions/*.instructions.md`** — Path-scoped rules with `applyTo:` frontmatter. Existing:
+  - [go-tests.instructions.md](instructions/go-tests.instructions.md) — `applyTo: "**/*_test.go"`
+  - [provider.instructions.md](instructions/provider.instructions.md) — `applyTo: "internal/provider/**/*.go"`
+  - [image-templates.instructions.md](instructions/image-templates.instructions.md) — `applyTo: "image-templates/**/*.yml"`
+- **`.github/prompts/*.prompt.md`** — Reusable task prompts. Existing:
+  - [add-os-provider.prompt.md](prompts/add-os-provider.prompt.md)
+- **`.github/chatmodes/*.chatmode.md`** — Custom agent modes with restricted tool sets (e.g. a read-only "reviewer" mode). _Not yet added._
+- **`.vscode/mcp.json`** — Shared MCP servers (e.g. GitHub, fetch, container tooling) so every contributor's agent has the same capabilities. _Not yet added._
+- **`AGENTS.md`** (repo root) — mirrors a subset of these instructions for non-Copilot agents (Cursor, Claude Code, etc.). Keep [AGENTS.md](../AGENTS.md) and this file in sync.
+
+When a section here grows past a screenful or only applies to a subdirectory, split it out into one of the above and leave a one-line summary + pointer behind.
+
+---
 
 ## Key Files
 
-- `image-templates/*.yml` - Example image templates
-- `config/osv/` - OS-specific default configurations
-- `internal/config/config.go` - `ImageTemplate` struct definition
-- `internal/provider/provider.go` - Provider interface
-- `internal/utils/logger/` - Project logger (zap-based)
-- `internal/utils/network/securehttp.go` - Secure HTTP client
-- `internal/utils/shell/shell.go` - Command execution with allowlist
-- `.golangci.yml` - Linter configuration
-- `.coverage-threshold` - Current test coverage threshold
-- `docs/architecture/` - ADRs and design docs
+- `image-templates/*.yml` — Example image templates
+- `config/osv/` — OS-specific default configurations
+- `internal/config/config.go` — `ImageTemplate` struct definition
+- `internal/provider/provider.go` — Provider interface
+- `internal/utils/logger/` — Project logger (zap-based)
+- `internal/utils/network/securehttp.go` — Secure HTTP client
+- `internal/utils/shell/shell.go` — Command execution with allowlist
+- `.golangci.yml` — Linter configuration
+- `.coverage-threshold` — Current test coverage threshold
+- `docs/architecture/` — ADRs and design docs

--- a/.github/instructions/go-tests.instructions.md
+++ b/.github/instructions/go-tests.instructions.md
@@ -1,0 +1,79 @@
+---
+applyTo: "**/*_test.go"
+---
+
+# Go test conventions
+
+Use these in addition to the root `copilot-instructions.md`.
+
+## Framework
+- **stdlib `testing` only.** No `testify`, `gomega`, `ginkgo`, or other assertion libs.
+- One test file per source file: `foo.go` → `foo_test.go`, same package (use `_test` package only when you need to test through the public API to break an import cycle).
+
+## Structure
+- **Table-driven** by default. Sub-tests via `t.Run(tt.name, …)`.
+- **AAA**: Arrange, Act, Assert — keep the three blocks visually separated by a blank line.
+- Helpers must call `t.Helper()` on the first line so failure lines point at the caller.
+
+```go
+func TestFoo(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    string
+        wantErr bool
+    }{
+        {name: "happy path", input: "a", want: "A"},
+        {name: "empty", input: "", wantErr: true},
+    }
+    for _, tt := range tests {
+        tt := tt
+        t.Run(tt.name, func(t *testing.T) {
+            t.Parallel()
+            got, err := Foo(tt.input)
+            if (err != nil) != tt.wantErr {
+                t.Fatalf("Foo(%q) err = %v, wantErr %v", tt.input, err, tt.wantErr)
+            }
+            if got != tt.want {
+                t.Errorf("Foo(%q) = %q, want %q", tt.input, got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## Filesystem & state
+- Always use `t.TempDir()` for files/dirs. **Never** write into the repo tree or `/tmp` directly.
+- Reset package-level state in `TestMain` or at the top of each test (see `resetBuildFlags()` in `cmd/image-composer-tool/build_test.go`).
+- Use `t.Cleanup(...)` for teardown instead of `defer` when the cleanup must run in a sub-test.
+
+## Parallelism
+- Add `t.Parallel()` to every IO-light, state-free test (top-level **and** inside sub-tests).
+- Capture the loop var (`tt := tt`) before `t.Parallel()` in table-driven sub-tests.
+- Do **not** parallelize tests that mutate globals, chdir, set env vars without `t.Setenv`, or touch shared fixtures.
+
+## Env / context
+- Use `t.Setenv("KEY", "val")` — never `os.Setenv` (auto-restored, parallel-safe).
+- Pass `context.Background()` or `t.Context()` (Go 1.24+) — don't reach for `context.TODO()` in tests.
+
+## Skipping
+- `t.Skip("reason")` for environment-dependent tests (require root, network, qemu, etc.).
+- Gate slow/integration tests behind `testing.Short()`:
+  ```go
+  if testing.Short() { t.Skip("skipping in -short mode") }
+  ```
+
+## Assertions
+- Plain `if`/`t.Errorf`/`t.Fatalf`. Use `t.Errorf` to continue, `t.Fatalf` to stop.
+- For struct equality: `reflect.DeepEqual` or `cmp.Diff` (already a transitive dep — verify before adding).
+- Always include the **input and expected vs. got** in failure messages.
+
+## Coverage
+- Aim to keep the package at or above the repo threshold (`.coverage-threshold`).
+- Cover error paths, not just the happy path. `errcheck` will catch ignored errors; tests should exercise them.
+
+## Anti-patterns
+- ❌ `time.Sleep` for synchronization — use channels or `eventually`-style polling with a deadline.
+- ❌ Tests that depend on test execution order.
+- ❌ Network calls to real hosts — use `httptest.Server` or fixtures under `testdata/`.
+- ❌ Logging via `fmt.Println` in tests — use `t.Logf`.

--- a/.github/instructions/image-templates.instructions.md
+++ b/.github/instructions/image-templates.instructions.md
@@ -1,0 +1,73 @@
+---
+applyTo: "image-templates/**/*.yml"
+---
+
+# Image template conventions
+
+Use these in addition to the root `copilot-instructions.md`. Schema: [os-image-template.schema.json](../../internal/config/schema/os-image-template.schema.json).
+
+## Naming
+
+`<dist>-<arch>-<purpose>-<imageType>.yml`
+
+Examples: `emt3-x86_64-minimal-raw.yml`, `ubuntu24-aarch64-edge-raw.yml`, `azl3-x86_64-minimal-iso.yml`.
+
+- `<dist>`: lowercase distro + major version (`emt3`, `azl3`, `elxr12`, `ubuntu24`, `debian13`, `rcd10`).
+- `<arch>`: `x86_64` or `aarch64` (match Go's `runtime.GOARCH` convention only when the schema requires it — otherwise use these).
+- `<purpose>`: `minimal`, `edge`, `dlstreamer`, `desktop-virtualization`, etc.
+- `<imageType>`: `raw`, `iso`, `initrd`.
+
+## Required sections for a user-facing template
+
+```yaml
+metadata:
+  description: One-line summary of what this image is for.
+  use_cases:
+    - Short bullet
+    - Another bullet
+  keywords: [edge, minimal, ubuntu]
+
+image:
+  name: my-image
+  version: 1.0.0
+
+target:
+  os: ubuntu          # must match a provider's OsName
+  os_version: "24.04"
+  arch: x86_64
+```
+
+Everything else (`packages`, `disk`, `bootloader`, …) is supplied by `config/osv/{osname}/` defaults and only needs to appear when the user overrides it.
+
+## Merge semantics — important
+
+| Field | Behavior |
+|---|---|
+| `packages` (and nested package lists) | **Additive** — user entries are merged by name with defaults |
+| `disk` | **Replace** — providing `disk` discards the OS default entirely; copy the default and edit it |
+| `metadata` | Replace per top-level key |
+| Scalar overrides (`image.name`, `target.os_version`, …) | Replace |
+
+If you intend to *remove* a default package, you currently cannot do that with the merge — open an issue rather than working around it.
+
+## Authoring rules
+
+- Always include the `metadata` block — it powers template discoverability and `image-composer-tool list`.
+- Reference packages by exact name (no globs).
+- Pin kernel and bootloader versions explicitly when reproducibility matters.
+- Do **not** embed secrets, tokens, or private repo URLs. Use the `auth` block + env vars.
+- Keep YAML 2-space indented, no tabs. Sort top-level keys: `metadata`, `image`, `target`, `packages`, `disk`, `bootloader`, `auth`, rest.
+
+## Before committing
+
+```sh
+image-composer-tool validate -t image-templates/<your-template>.yml
+```
+
+The validator runs the JSON schema and additional semantic checks. CI will reject templates that fail validation.
+
+## When updating an existing template
+
+- Bump `image.version` if behavior changes for downstream consumers.
+- Note user-visible changes in `docs/release-notes.md`.
+- If you change a default in `config/osv/`, audit every template under `image-templates/` that depends on it.

--- a/.github/instructions/image-templates.instructions.md
+++ b/.github/instructions/image-templates.instructions.md
@@ -32,31 +32,32 @@ image:
   version: 1.0.0
 
 target:
-  os: ubuntu          # must match a provider's OsName
-  os_version: "24.04"
+  os: ubuntu          # must match a provider's OsName (target.os enum)
+  dist: ubuntu24      # distro + major version (target.dist)
   arch: x86_64
+  imageType: raw      # raw | img | iso
 ```
 
-Everything else (`packages`, `disk`, `bootloader`, …) is supplied by `config/osv/{osname}/` defaults and only needs to appear when the user overrides it.
+Everything else (`systemConfig` with its `packages`, `bootloader`, …, plus `disk` and `packageRepositories`) is supplied by `config/osv/{osname}/` defaults and only needs to appear when the user overrides it.
 
 ## Merge semantics — important
 
 | Field | Behavior |
 |---|---|
-| `packages` (and nested package lists) | **Additive** — user entries are merged by name with defaults |
+| `systemConfig.packages` (and nested package lists) | **Additive** — user entries are merged by name with defaults |
 | `disk` | **Replace** — providing `disk` discards the OS default entirely; copy the default and edit it |
 | `metadata` | Replace per top-level key |
-| Scalar overrides (`image.name`, `target.os_version`, …) | Replace |
+| Scalar overrides (`image.name`, `target.dist`, …) | Replace |
 
 If you intend to *remove* a default package, you currently cannot do that with the merge — open an issue rather than working around it.
 
 ## Authoring rules
 
 - Always include the `metadata` block — it powers template discoverability and `image-composer-tool list`.
-- Reference packages by exact name (no globs).
+- Reference packages by exact name under `systemConfig.packages` (glob patterns like `wayland*` are allowed; versioned globs are not).
 - Pin kernel and bootloader versions explicitly when reproducibility matters.
-- Do **not** embed secrets, tokens, or private repo URLs. Use the `auth` block + env vars.
-- Keep YAML 2-space indented, no tabs. Sort top-level keys: `metadata`, `image`, `target`, `packages`, `disk`, `bootloader`, `auth`, rest.
+- Do **not** embed secrets, tokens, or private repo URLs. For repository GPG verification use `packageRepositories[].pkey` / `pkeys`.
+- Keep YAML 2-space indented, no tabs. Top-level keys are `metadata`, `image`, `target`, `disk`, `systemConfig`, `packageRepositories` — keep them in that order.
 
 ## Before committing
 

--- a/.github/instructions/provider.instructions.md
+++ b/.github/instructions/provider.instructions.md
@@ -1,0 +1,87 @@
+---
+applyTo: "internal/provider/**/*.go"
+---
+
+# OS Provider conventions
+
+Use these in addition to the root `copilot-instructions.md`. The `Provider` interface is defined in [internal/provider/provider.go](../../internal/provider/provider.go).
+
+## Package layout
+
+Each provider lives in `internal/provider/{osname}/` and **must** export:
+
+```go
+// OsName must match the template's target.os. It may be multi-word,
+// e.g. "ubuntu", "wind-river-elxr", "redhat-compatible-distro".
+const OsName = "ubuntu"
+
+// Register constructs the provider and registers it with the core
+// provider registry. Called from cmd/image-composer-tool/build.go.
+func Register(targetOs, targetDist, targetArch string) error {
+    provider.Register(&ubuntu{ /* fields */ }, targetDist, targetArch)
+    return nil
+}
+```
+
+`Register()` is invoked from the `switch` in `cmd/image-composer-tool/build.go`
+(`case ubuntu.OsName: ubuntu.Register(os, dist, arch)`). Registration is explicit —
+do not auto-register via `init()`. The core `provider.Register(p, dist, arch)` keys
+the provider by `p.Name(dist, arch)`.
+
+## Interface contract
+
+The `Provider` interface is (see [internal/provider/provider.go](../../internal/provider/provider.go)):
+
+```go
+type Provider interface {
+    Name(dist, arch string) string
+    Init(dist, arch string) error
+    PreProcess(template *config.ImageTemplate) error
+    BuildImage(template *config.ImageTemplate) error
+    PostProcess(template *config.ImageTemplate, err error) error
+}
+```
+
+Implement each method — they run in this order:
+
+| Method | Responsibility | Allowed side effects |
+|---|---|---|
+| `Name(dist, arch)` | Return the unique provider id (combines OS, dist, arch) | None |
+| `Init(dist, arch)` | One-time setup: import GPG keys, register repos | Key/repo state, empty dirs |
+| `PreProcess(template)` | Resolve + download packages into the cache | Network IO, writes to `cache/pkgCache/` |
+| `BuildImage(template)` | Create chroot, install packages, run image-maker | Writes to workspace, mounts/unmounts |
+| `PostProcess(template, err)` | Final steps + cleanup; `err` is the build error (nil on success) | Writes to output dir, unmounts |
+
+> Note: the interface does **not** take `context.Context` — the build pipeline
+> does not currently thread a context. Only `internal/ai/` uses `context.Context`.
+> Do not add a `ctx` parameter to provider methods to "match Go convention" —
+> match the existing interface instead.
+
+## Required patterns
+
+- **Logger.** Declare `var log = logger.Logger()` at package level (every existing provider does). Log at `Info` for phase boundaries, `Debug` for per-package detail, `Warn`/`Error` for recoverable/fatal issues.
+- **Shell.** Use `internal/utils/shell` — never raw `exec.Command`. New commands must be added to the allowlist with justification.
+- **HTTP.** Use `network.GetSecureHTTPClient()` for any download. Never `http.DefaultClient`.
+- **Paths.** `filepath.Clean` any path derived from the template. Chroot dirs are `0700`.
+- **Cleanup.** Named returns + `defer` for unmounts and tempdir removal. Never leave loop devices or bind mounts dangling on error.
+
+## Package resolution
+
+- Debian-family: use helpers in `internal/ospackage/debutils/`.
+- RPM-family: use helpers in `internal/ospackage/rpmutils/`.
+- Do not shell out to `apt`/`dnf` inside the provider — those calls belong in the chroot installers (`internal/chroot/deb/`, `internal/chroot/rpm/`).
+
+## Errors
+
+- Wrap with phase context: `fmt.Errorf("ubuntu PreProcess: resolve deps: %w", err)`.
+- Missing-package errors should populate the `Missing_Requested_Packages_*.json` report (see existing providers for the pattern).
+- Surface unrecoverable errors up to `cmd/`; do not call `os.Exit` from a provider.
+
+## Tests
+
+- Mock the chroot and shell layers via interfaces — never run a real `apt-get` from a unit test.
+- Per-OS smoke build runs in CI integration jobs, not in `earthly +test`.
+
+> Adding a whole new provider? Use the step-by-step workflow in
+> [.github/prompts/add-os-provider.prompt.md](../prompts/add-os-provider.prompt.md)
+> (run `/add-os-provider` in chat). This file is the *conventions* reference it relies on.

--- a/.github/prompts/add-os-provider.prompt.md
+++ b/.github/prompts/add-os-provider.prompt.md
@@ -1,0 +1,50 @@
+---
+mode: agent
+description: Scaffold a new OS provider end-to-end (package, registration, defaults, template, tests, docs).
+---
+
+# Add a new OS provider
+
+You are adding a new OS provider to image-composer-tool. Follow the project's [provider conventions](../instructions/provider.instructions.md) and [test conventions](../instructions/go-tests.instructions.md).
+
+## Inputs to collect from the user
+
+If any of these are missing, ask **once** with `vscode_askQuestions` (one batch, all questions) before writing any code:
+
+1. **OS name** (lowercase, used as `OsName` and in template `target.os`), e.g. `fedora`.
+2. **OS family** — `deb` or `rpm` (decides which installer + ospackage helpers to wire up).
+3. **Supported architectures** — any subset of `x86_64`, `aarch64`.
+4. **Default OS version** to ship with (e.g. `40`).
+5. **Upstream package repos** — base URL(s) and signing-key location.
+6. **Image types to support initially** — any subset of `raw`, `iso`, `initrd`.
+
+## Plan
+
+Create a `manage_todo_list` covering exactly these steps, then execute in order:
+
+1. **Read the closest analogue.** If `deb`, study `internal/provider/ubuntu/`; if `rpm`, study `internal/provider/azl/` (or `emt`). Read the full provider file plus its tests.
+2. **Scaffold the package** at `internal/provider/{osname}/{osname}.go`, matching the interface in `internal/provider/provider.go`:
+   - `const OsName = "{osname}"` (must match the template `target.os`; may be multi-word).
+   - A provider struct (e.g. `type {osname} struct{ … }`) implementing the interface methods.
+   - `func Register(targetOs, targetDist, targetArch string) error` that calls `provider.Register(&{osname}{…}, targetDist, targetArch)`.
+   - Implement `Name(dist, arch string) string`, `Init(dist, arch string) error`, `PreProcess(template *config.ImageTemplate) error`, `BuildImage(template *config.ImageTemplate) error`, `PostProcess(template *config.ImageTemplate, err error) error`. **No `context.Context`** — the interface does not take one. Wrap errors with phase context and use `var log = logger.Logger()`.
+3. **Wire registration** in `cmd/image-composer-tool/build.go` — add a `case {osname}.OsName:` arm to the `switch os` that calls `{osname}.Register(os, dist, arch)` and wraps the error. Confirm by re-reading the edited section.
+4. **Default configs** in `config/osv/{osname}/` — mirror the layout of the analogue provider (package lists, disk layout, bootloader). Use the user-provided repo URLs and signing keys.
+5. **Example templates** in `image-templates/`, one per chosen image type, named `<osname><majorver>-<arch>-minimal-<imageType>.yml`. Each must have a populated `metadata` block.
+6. **Unit tests** in `internal/provider/{osname}/{osname}_test.go` covering at minimum: the `OsName` constant, `Name(dist, arch)` output, `Init` error paths, and registration. Mock chroot + shell — no real package installs.
+7. **Docs**:
+   - Add the provider to `docs/architecture/architecture.md`.
+   - Add a release note under `docs/release-notes.md`.
+   - Update the **Adding a New OS Provider** section of `.github/copilot-instructions.md` only if the *steps* changed (not just the provider list).
+8. **Validate**:
+   - `image-composer-tool validate -t image-templates/<new-template>.yml` for each new template.
+   - `go test ./internal/provider/{osname}/...`
+   - `earthly +test-quick` and `earthly +lint` (or Go fallbacks).
+9. **Summary** — report what was created, what tests passed, and what the user should run to do a real integration build.
+
+## Guardrails
+
+- Do **not** add new third-party dependencies without asking.
+- Do **not** call `apt`/`dnf` directly from the provider — use `internal/chroot/{deb,rpm}/`.
+- Do **not** commit secrets or private repo URLs to fixtures.
+- Stay within the directories listed above; no drive-by edits elsewhere.

--- a/.github/prompts/add-os-provider.prompt.md
+++ b/.github/prompts/add-os-provider.prompt.md
@@ -30,7 +30,7 @@ Create a `manage_todo_list` covering exactly these steps, then execute in order:
    - Implement `Name(dist, arch string) string`, `Init(dist, arch string) error`, `PreProcess(template *config.ImageTemplate) error`, `BuildImage(template *config.ImageTemplate) error`, `PostProcess(template *config.ImageTemplate, err error) error`. **No `context.Context`** — the interface does not take one. Wrap errors with phase context and use `var log = logger.Logger()`.
 3. **Wire registration** in `cmd/image-composer-tool/build.go` — add a `case {osname}.OsName:` arm to the `switch os` that calls `{osname}.Register(os, dist, arch)` and wraps the error. Confirm by re-reading the edited section.
 4. **Default configs** in `config/osv/{osname}/` — mirror the layout of the analogue provider (package lists, disk layout, bootloader). Use the user-provided repo URLs and signing keys.
-5. **Example templates** in `image-templates/`, one per chosen image type, named `<osname><majorver>-<arch>-minimal-<imageType>.yml`. Each must have a populated `metadata` block.
+5. **Example templates** in `image-templates/`, one per chosen image type, named `<dist>-<arch>-minimal-<imageType>.yml` (filenames use the `target.dist` value, e.g. `azl3-…`, `ubuntu24-…`, not the `OsName`). Each must have a populated `metadata` block.
 6. **Unit tests** in `internal/provider/{osname}/{osname}_test.go` covering at minimum: the `OsName` constant, `Name(dist, arch)` output, `Init` error paths, and registration. Mock chroot + shell — no real package installs.
 7. **Docs**:
    - Add the provider to `docs/architecture/architecture.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+# AGENTS.md — image-composer-tool
+
+> Cross-tool agent guide (Cursor, Claude Code, Aider, Codex CLI, etc.).
+> GitHub Copilot reads [`.github/copilot-instructions.md`](.github/copilot-instructions.md) — that file is the source of truth. Keep this one in sync with its TL;DR and key conventions.
+
+---
+
+## TL;DR
+
+1. **Plan, then act.** For any multi-step task, write a short plan and check items off as you go.
+2. **Gather context efficiently.** Parallel reads/searches; read large ranges in one call; stop searching once you can act.
+3. **Implement, don't just suggest.** Smallest diff that solves the problem.
+4. **Verify after every edit.** Run package tests and `earthly +test-quick` + `earthly +lint` (or Go/golangci-lint fallbacks) before declaring done.
+5. **Match existing patterns** — see [Project conventions](#project-conventions) below.
+6. **Stay in scope.** No drive-by refactors, no new comments/docstrings on code you didn't change, no abstractions for one-off use.
+7. **Update docs in the same PR** when behavior changes.
+8. **Never bypass safety gates.** No `--no-verify`, no `git push --force`, no skipping tests. Confirm before destructive or shared-system actions.
+
+---
+
+## Architecture at a glance
+
+Builds custom Linux images from pre-built packages.
+
+- `internal/provider/` — per-OS orchestrators (`azl`, `debian13`, `elxr`, `emt`, `rcd`, `ubuntu`). Each implements the `Provider` interface (`Name`, `Init`, `PreProcess`, `BuildImage`, `PostProcess`) and exports `OsName` + `Register()`.
+- `internal/image/` — output formats: `rawmaker/`, `isomaker/`, `initrdmaker/`.
+- `internal/chroot/` — isolated build envs with `deb/` and `rpm/` installers.
+- `internal/config/` — template loading, defaults+user merge, validation.
+- `internal/ospackage/` — `debutils/`, `rpmutils/` for dependency resolution.
+- `cmd/image-composer-tool/` — CLI entrypoint and provider registration.
+
+Data flow: CLI → Config loads template → `Provider.Init` → `PreProcess` (downloads) → `BuildImage` (chroot + image-maker) → `PostProcess`.
+
+---
+
+## Build, test, lint
+
+Prefer **Earthly** (used by CI). Fall back to plain Go if Earthly is unavailable.
+
+| Task | Earthly | Go fallback |
+|---|---|---|
+| Build | `earthly +build` | `go build ./...` |
+| Test (fast) | `earthly +test-quick` | `go test ./...` |
+| Test (coverage) | `earthly +test` | `go test -coverprofile=coverage.out ./...` |
+| Lint | `earthly +lint` | `golangci-lint run` |
+
+Coverage threshold lives in `.coverage-threshold` and auto-ratchets.
+
+---
+
+## Project conventions
+
+- **Logger:** `var log = logger.Logger()` from `internal/utils/logger`. Never `fmt.Println` or stdlib `log`.
+- **HTTP:** `network.GetSecureHTTPClient()` / `NewSecureHTTPClient()` from `internal/utils/network`. Never `http.DefaultClient`.
+- **Shell:** `internal/utils/shell` (allowlisted). Never raw `exec.Command`.
+- **Paths:** Always `filepath.Clean` paths derived from user input.
+- **Errors:** Wrap with context: `fmt.Errorf("phase X: %w", err)`. Never ignore with `_`.
+- **Cleanup:** Named returns + `defer` (not goto-fail style).
+- **Tests:** stdlib `testing` only — no testify. Table-driven with `t.Run`. `t.TempDir()` for filesystem. `t.Parallel()` where safe.
+- **Function/line limits:** ≤50 lines / 120 cols. Use a config struct beyond 4–5 params.
+- **Linters enforced:** `govet`, `gofmt`, `errcheck`, `staticcheck`, `unused`, `gosimple`.
+
+For path-scoped detail, see `.github/instructions/`:
+
+- [`go-tests.instructions.md`](.github/instructions/go-tests.instructions.md) — Go test conventions
+- [`provider.instructions.md`](.github/instructions/provider.instructions.md) — OS provider conventions
+- [`image-templates.instructions.md`](.github/instructions/image-templates.instructions.md) — YAML image template conventions
+
+---
+
+## Security
+
+- TLS 1.2+ via the project HTTP client.
+- Shell allowlist enforced — adding a new command requires justification.
+- Validate templates against `os-image-template.schema.json` (`image-composer-tool validate -t …`).
+- File permissions: `0700` chroot dirs, `0755` general dirs, `0644` data, `0640` logs.
+- Never embed secrets in fixtures, code, or logs.
+- CI gates: Trivy (HIGH/CRITICAL fails), Gitleaks, Zizmor.
+
+---
+
+## Git & PRs
+
+- Sign commits (`git commit -S`).
+- Conventional commits: `type(scope): description` (`feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `build`, `ci`, `perf`).
+- Branches: `feature/`, `fix/`, `docs/`, `refactor/`.
+- Use `.github/PULL_REQUEST_TEMPLATE.md`.
+- **Never** force-push shared branches, **never** `--no-verify`.
+- Do **not** add AI co-author trailers unless the repo asks for them.
+- The `gh` CLI is available — prefer it over manual web steps.
+
+---
+
+## Anti-patterns
+
+- Adding `// TODO`, docstrings, or type annotations to unchanged code.
+- "Helper" packages or interfaces for a single caller.
+- Catching errors only to rewrap with no added context.
+- Pulling new dependencies without stating why.
+- Generating standalone "summary of changes" markdown files — put that in the PR body.
+
+---
+
+## Reusable prompts
+
+- [`.github/prompts/add-os-provider.prompt.md`](.github/prompts/add-os-provider.prompt.md) — scaffold a new OS provider end-to-end.
+
+---
+
+## Key files
+
+- `internal/config/config.go` — `ImageTemplate` struct
+- `internal/provider/provider.go` — `Provider` interface
+- `internal/utils/logger/` — zap-based project logger
+- `internal/utils/network/securehttp.go` — secure HTTP client
+- `internal/utils/shell/shell.go` — command allowlist
+- `image-templates/*.yml` — example templates
+- `config/osv/` — per-OS defaults
+- `.golangci.yml` — lint config
+- `.coverage-threshold` — current coverage floor
+- `docs/architecture/` — ADRs and design docs
+
+---
+
+*If you update conventions here, update [`.github/copilot-instructions.md`](.github/copilot-instructions.md) too — and vice versa.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 
 Builds custom Linux images from pre-built packages.
 
-- `internal/provider/` — per-OS orchestrators (`azl`, `debian13`, `elxr`, `emt`, `rcd`, `ubuntu`). Each implements the `Provider` interface (`Name`, `Init`, `PreProcess`, `BuildImage`, `PostProcess`) and exports `OsName` + `Register()`.
+- `internal/provider/` — per-OS orchestrators. Directory names `azl`, `debian13`, `elxr`, `emt`, `rcd`, `ubuntu` map to `target.os` / `OsName` values `azure-linux`, `debian`, `wind-river-elxr`, `edge-microvisor-toolkit`, `redhat-compatible-distro`, `ubuntu` (use the latter in templates). Each implements the `Provider` interface (`Name`, `Init`, `PreProcess`, `BuildImage`, `PostProcess`) and exports `OsName` + `Register()`.
 - `internal/image/` — output formats: `rawmaker/`, `isomaker/`, `initrdmaker/`.
 - `internal/chroot/` — isolated build envs with `deb/` and `rpm/` installers.
 - `internal/config/` — template loading, defaults+user merge, validation.


### PR DESCRIPTION
#### Merge Checklist

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x ] Ready to merge

#### Description

Updated the repo's AI agent customization and splits guidance into scoped,
auto-loading companion files (current VS Code Copilot best practice).

- **`.github/copilot-instructions.md`** - rewritten with a TL;DR rules block and
  agent-workflow guidance; provider/testing/template detail condensed into pointers
  to the new scoped files (DRY).
- **`.github/instructions/*.instructions.md`** - path-scoped via `applyTo`:
  Go tests (`**/*_test.go`), providers (`internal/provider/**/*.go`),
  image templates (`image-templates/**/*.yml`).
- **`.github/prompts/*.prompt.md`** - reusable `mode: agent` prompt: `add-os-provider`.
- **`AGENTS.md`** - mirrors conventions for non-Copilot agents (Cursor, Claude Code, Aider).

Docs-only change - no source code affected.

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested?

- `earthly +lint` - SUCCESS.
- `go build ./cmd/... ./internal/...` and `go vet` - pass.
- No source files changed, so no behavioral tests apply.
