### PR TITLE
fix chroot stale cache not clean up

### DIFF
--- a/internal/ospackage/debutils/download.go
+++ b/internal/ospackage/debutils/download.go
@@ -472,23 +472,45 @@ func clearDebMetadataCache() {
 	}
 }
 
-// clearDebPackageCache removes all .deb files from cacheDir and invalidates
-// the per-repo metadata cache (packages.parsed.json) so that a full re-download
-// including fresh repository metadata is performed on the next run.
+// clearDebPackageCache removes all .deb files from cacheDir, including those in
+// nested subdirectories (e.g. the chrootenv/ and initrd/ package caches), and
+// invalidates the per-repo metadata cache (packages.parsed.json) so that a full
+// re-download including fresh repository metadata is performed on the next run.
+//
+// Subdirectories must be cleared too: the image build's local-repo step can
+// index package files under cacheDir recursively, so stale .deb files left in
+// subdirectories could shadow the correct package version.
 func clearDebPackageCache(cacheDir string) error {
 	log := logger.Logger()
-	pattern := filepath.Join(cacheDir, "*.deb")
-	files, err := filepath.Glob(pattern)
-	if err != nil {
-		return fmt.Errorf("glob %q: %w", pattern, err)
+	removedCount := 0
+
+	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
+		log.Debugf("cache directory %s does not exist; skipping cleanup", cacheDir)
+		clearDebMetadataCache()
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("stat cache directory %q: %w", cacheDir, err)
 	}
-	for _, f := range files {
-		if err := os.Remove(f); err != nil {
-			return fmt.Errorf("removing cached file %s: %w", f, err)
+
+	err := filepath.WalkDir(cacheDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
-		log.Debugf("removed stale cached file: %s", filepath.Base(f))
+		if d.IsDir() || filepath.Ext(d.Name()) != ".deb" {
+			return nil
+		}
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("removing cached file %s: %w", path, err)
+		}
+		removedCount++
+		log.Debugf("removed stale cached file: %s", filepath.Base(path))
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walking cache directory %q: %w", cacheDir, err)
 	}
-	log.Infof("cleared %d stale DEB files from cache directory %s", len(files), cacheDir)
+
+	log.Infof("cleared %d stale DEB files from cache directory %s", removedCount, cacheDir)
 	clearDebMetadataCache()
 	return nil
 }

--- a/internal/ospackage/debutils/download_test.go
+++ b/internal/ospackage/debutils/download_test.go
@@ -428,6 +428,19 @@ func TestClearDebPackageCache(t *testing.T) {
 			wantLeft: []string{"notes.txt"},
 		},
 		{
+			name: "clears deb files in nested subdirectories",
+			setup: func(dir string) {
+				nested := filepath.Join(dir, "chrootenv")
+				if err := os.MkdirAll(nested, 0755); err != nil {
+					t.Fatalf("failed to create nested directory: %v", err)
+				}
+				_ = os.WriteFile(filepath.Join(dir, "bash_1.0_amd64.deb"), []byte("x"), 0644)
+				_ = os.WriteFile(filepath.Join(nested, "libsystemd0_255.4-1ubuntu8.15-ecir8_amd64.deb"), []byte("x"), 0644)
+				_ = os.WriteFile(filepath.Join(nested, "keep.txt"), []byte("x"), 0644)
+			},
+			wantLeft: []string{"chrootenv/keep.txt"},
+		},
+		{
 			name:  "empty cache dir is a no-op",
 			setup: func(dir string) {},
 		},
@@ -441,7 +454,20 @@ func TestClearDebPackageCache(t *testing.T) {
 				t.Fatalf("clearDebPackageCache() unexpected error: %v", err)
 			}
 
-			debs, _ := filepath.Glob(filepath.Join(dir, "*.deb"))
+			var debs []string
+			walkErr := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if d.IsDir() || filepath.Ext(d.Name()) != ".deb" {
+					return nil
+				}
+				debs = append(debs, path)
+				return nil
+			})
+			if walkErr != nil {
+				t.Fatalf("failed to walk test cache dir: %v", walkErr)
+			}
 			if len(debs) != 0 {
 				t.Errorf("expected no .deb files after clear, got %v", debs)
 			}
@@ -490,6 +516,14 @@ func TestClearDebMetadataCache(t *testing.T) {
 		if _, statErr := os.Stat(f); !os.IsNotExist(statErr) {
 			t.Errorf("expected packages.parsed.json in build path %d (%s) to be removed", i, dir)
 		}
+	}
+}
+
+func TestClearDebPackageCache_MissingDirIsNoOp(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "does-not-exist")
+
+	if err := clearDebPackageCache(dir); err != nil {
+		t.Fatalf("clearDebPackageCache() unexpected error for missing dir: %v", err)
 	}
 }
 

--- a/internal/ospackage/debutils/download_test.go
+++ b/internal/ospackage/debutils/download_test.go
@@ -434,9 +434,15 @@ func TestClearDebPackageCache(t *testing.T) {
 				if err := os.MkdirAll(nested, 0755); err != nil {
 					t.Fatalf("failed to create nested directory: %v", err)
 				}
-				_ = os.WriteFile(filepath.Join(dir, "bash_1.0_amd64.deb"), []byte("x"), 0644)
-				_ = os.WriteFile(filepath.Join(nested, "libsystemd0_255.4-1ubuntu8.15-ecir8_amd64.deb"), []byte("x"), 0644)
-				_ = os.WriteFile(filepath.Join(nested, "keep.txt"), []byte("x"), 0644)
+				for _, p := range []string{
+					filepath.Join(dir, "bash_1.0_amd64.deb"),
+					filepath.Join(nested, "libsystemd0_255.4-1ubuntu8.15-ecir8_amd64.deb"),
+					filepath.Join(nested, "keep.txt"),
+				} {
+					if err := os.WriteFile(p, []byte("x"), 0644); err != nil {
+						t.Fatalf("failed to write %s: %v", p, err)
+					}
+				}
 			},
 			wantLeft: []string{"chrootenv/keep.txt"},
 		},


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->

This PR fixes stale DEB package cache cleanup by ensuring cached .deb files are removed not only from the top-level cache directory but also from nested subdirectories used during image builds (e.g., chroot/initrd caches). This helps prevent stale packages from being indexed and shadowing the intended versions in subsequent runs.

Changes:

Update DEB cache cleanup to recursively remove .deb files under the cache directory and gracefully no-op when the cache directory is missing.
Expand unit tests to cover nested subdirectory cleanup and the missing-directory no-op behavior.

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->