### PR TITLE
Enabled processing of concatenated keys in a file and update pkey links in dlstreamer image templates…

### DIFF
--- a/image-templates/ubuntu24-x86_64-dlstreamer.yml
+++ b/image-templates/ubuntu24-x86_64-dlstreamer.yml
@@ -46,9 +46,9 @@ packageRepositories:
     pkey: "https://apt.repos.intel.com/edgeai/dlstreamer/GPG-PUB-KEY-INTEL-DLS.gpg"
 
   - codename: "noble"
-    url: "https://repositories.intel.com/gpu/ubuntu"
-    pkey: "https://repositories.intel.com/gpu/intel-graphics.key"
-    component: "unified"
+    url: "https://ppa.launchpadcontent.net/kobuk-team/intel-graphics/ubuntu"
+    pkey: "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0C0E6AF955CE463C03FC51574D098D70AFBE5E1F"
+    component: "main"
 
 disk:
   name: Minimal_Raw # 1:1 mapping to the systemConfigs name

--- a/internal/ospackage/debutils/verify.go
+++ b/internal/ospackage/debutils/verify.go
@@ -62,6 +62,50 @@ func isBinaryGPGKey(data []byte) bool {
 	return float64(printableCount)/float64(checkLength) < 0.7
 }
 
+// parseKeyring loads every PGP key in data into a single EntityList. ProtonMail's
+// openpgp.ReadArmoredKeyRing stops after the first armored block, which silently
+// drops every later entity when a vendor key file concatenates multiple armored
+// blocks (e.g. a rotated primary alongside the active signing key). We dearmor
+// each block independently and feed the merged binary stream to ReadKeyRing so
+// the verifier can pick whichever key actually signed the Release file.
+func parseKeyring(data []byte) (openpgp.EntityList, error) {
+	beginMarker := []byte("-----BEGIN PGP PUBLIC KEY BLOCK-----")
+	if !bytes.Contains(data, beginMarker) {
+		return openpgp.ReadKeyRing(bytes.NewReader(data))
+	}
+
+	endMarker := []byte("-----END PGP PUBLIC KEY BLOCK-----")
+	var merged bytes.Buffer
+	rest := data
+	for {
+		start := bytes.Index(rest, beginMarker)
+		if start < 0 {
+			break
+		}
+		end := bytes.Index(rest[start:], endMarker)
+		if end < 0 {
+			return nil, fmt.Errorf("armored key block missing end marker")
+		}
+		blockEnd := start + end + len(endMarker)
+
+		block, err := armor.Decode(bytes.NewReader(rest[start:blockEnd]))
+		if err != nil {
+			return nil, fmt.Errorf("decoding armored key block: %w", err)
+		}
+		body, err := io.ReadAll(block.Body)
+		if err != nil {
+			return nil, fmt.Errorf("reading armored key body: %w", err)
+		}
+		merged.Write(body)
+		rest = rest[blockEnd:]
+	}
+
+	if merged.Len() == 0 {
+		return nil, fmt.Errorf("no armored key blocks decoded")
+	}
+	return openpgp.ReadKeyRing(&merged)
+}
+
 // convertBinaryGPGToAscii converts binary GPG key to ASCII armored format using Go crypto
 func convertBinaryGPGToAscii(binaryData []byte) ([]byte, error) {
 	// Try to parse the binary data as an OpenPGP key ring
@@ -165,18 +209,12 @@ func VerifyRelease(relPath string, relSignPath string, pKeyPath string) (bool, e
 		return false, fmt.Errorf("failed to read Release signature: %w", err)
 	}
 
-	// Try to import the public key - support both binary and armored formats
-	var keyring openpgp.EntityList
-
-	// First try as armored key (text format)
-	keyring, err = openpgp.ReadArmoredKeyRing(bytes.NewReader(keyringBytes))
+	// Load every PGP block in the key file. parseKeyring tolerates binary
+	// input and key files that concatenate multiple armored blocks, so the
+	// signing key is always present even when vendors ship rotated bundles.
+	keyring, err := parseKeyring(keyringBytes)
 	if err != nil {
-		log.Infof("Failed to parse as armored key, trying binary format: %v", err)
-		// Try as binary key format
-		keyring, err = openpgp.ReadKeyRing(bytes.NewReader(keyringBytes))
-		if err != nil {
-			return false, fmt.Errorf("failed to parse public key (tried both armored and binary formats): %w", err)
-		}
+		return false, fmt.Errorf("failed to parse public key: %w", err)
 	}
 
 	// Check if signature is binary or armored and verify accordingly

--- a/internal/ospackage/debutils/verify_test.go
+++ b/internal/ospackage/debutils/verify_test.go
@@ -1,6 +1,7 @@
 package debutils
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"os"
@@ -8,6 +9,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
 )
 
 // TestVerifyPackagegz tests the VerifyPackagegz function
@@ -749,6 +753,112 @@ func TestVerifyWithGoDeb(t *testing.T) {
 			}
 		})
 	}
+}
+
+// generateArmoredTestKey produces a self-contained ASCII-armored PGP public key
+// suitable for parseKeyring fixtures. Each call returns a freshly-generated key.
+func generateArmoredTestKey(t *testing.T, name, email string) []byte {
+	t.Helper()
+	entity, err := openpgp.NewEntity(name, "test", email, nil)
+	if err != nil {
+		t.Fatalf("NewEntity: %v", err)
+	}
+
+	var armored bytes.Buffer
+	w, err := armor.Encode(&armored, openpgp.PublicKeyType, nil)
+	if err != nil {
+		t.Fatalf("armor.Encode: %v", err)
+	}
+	if err := entity.Serialize(w); err != nil {
+		t.Fatalf("entity.Serialize: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("armor close: %v", err)
+	}
+	return armored.Bytes()
+}
+
+// TestParseKeyring covers the verify-side keyring parser, especially the
+// concatenated-armored-blocks case that the ProtonMail openpgp library does
+// not handle natively (it stops after the first block).
+func TestParseKeyring(t *testing.T) {
+	keyA := generateArmoredTestKey(t, "Test Key A", "a@example.invalid")
+	keyB := generateArmoredTestKey(t, "Test Key B", "b@example.invalid")
+
+	t.Run("single armored block", func(t *testing.T) {
+		ring, err := parseKeyring(keyA)
+		if err != nil {
+			t.Fatalf("parseKeyring: %v", err)
+		}
+		if len(ring) != 1 {
+			t.Fatalf("expected 1 entity, got %d", len(ring))
+		}
+	})
+
+	t.Run("two concatenated armored blocks", func(t *testing.T) {
+		// Mimic vendor key files (e.g. intel-graphics.key) that ship a
+		// rotated primary alongside the active signing key in one file.
+		concatenated := append(append([]byte{}, keyA...), keyB...)
+
+		ring, err := parseKeyring(concatenated)
+		if err != nil {
+			t.Fatalf("parseKeyring: %v", err)
+		}
+		if len(ring) != 2 {
+			t.Fatalf("expected 2 entities from concatenated blocks, got %d", len(ring))
+		}
+	})
+
+	t.Run("concatenated blocks separated by whitespace", func(t *testing.T) {
+		concatenated := append(append([]byte{}, keyA...), []byte("\n\n")...)
+		concatenated = append(concatenated, keyB...)
+
+		ring, err := parseKeyring(concatenated)
+		if err != nil {
+			t.Fatalf("parseKeyring: %v", err)
+		}
+		if len(ring) != 2 {
+			t.Fatalf("expected 2 entities, got %d", len(ring))
+		}
+	})
+
+	t.Run("binary keyring is forwarded as-is", func(t *testing.T) {
+		entity, err := openpgp.NewEntity("Binary Key", "test", "bin@example.invalid", nil)
+		if err != nil {
+			t.Fatalf("NewEntity: %v", err)
+		}
+		var binary bytes.Buffer
+		if err := entity.Serialize(&binary); err != nil {
+			t.Fatalf("entity.Serialize: %v", err)
+		}
+
+		ring, err := parseKeyring(binary.Bytes())
+		if err != nil {
+			t.Fatalf("parseKeyring: %v", err)
+		}
+		if len(ring) != 1 {
+			t.Fatalf("expected 1 entity from binary input, got %d", len(ring))
+		}
+	})
+
+	t.Run("armored block missing end marker", func(t *testing.T) {
+		truncated := bytes.Replace(keyA, []byte("-----END PGP PUBLIC KEY BLOCK-----"), []byte{}, 1)
+
+		_, err := parseKeyring(truncated)
+		if err == nil {
+			t.Fatalf("expected error for truncated armored block")
+		}
+		if !strings.Contains(err.Error(), "missing end marker") {
+			t.Fatalf("expected missing-end-marker error, got: %v", err)
+		}
+	})
+
+	t.Run("garbage input is rejected", func(t *testing.T) {
+		_, err := parseKeyring([]byte("this is not a key"))
+		if err == nil {
+			t.Fatalf("expected error for garbage input")
+		}
+	})
 }
 
 // TestResult tests the Result struct


### PR DESCRIPTION
… for intel-graphics packages

#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [ ] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

GPG key mismatch error was found previously due to the repo link changes for ubuntu 24 intel graphics and intel-graphics.key shipping two armored keys together in the same file. 

<!-- Fixes # (issue) -->
Fixed it by updating the intel graphics package repo for ubuntu noble and it's pkey link. For intel graphics repo in ubuntu 22 jammy, some changes has to be made in verify.go has to process a file that contains more than one key. 

Updated verify_test.go to match with the changes in verify.go 
#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->
Built the image and make sure gpg error isn't present in the log