### PR TITLE
fix(cli): show effective default for --workers flag in help output

### DIFF
--- a/cmd/image-composer-tool/build.go
+++ b/cmd/image-composer-tool/build.go
@@ -21,9 +21,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// defaultWorkers is the default number of concurrent download workers from config
+var defaultWorkers = config.DefaultGlobalConfig().Workers
+
 // Build command flags
 var (
-	workers            int    = -1 // -1 means use config file value
+	workers            int    = defaultWorkers
 	cacheDir           string = "" // Empty means use config file value
 	workDir            string = "" // Empty means use config file value
 	dotFile            string = "" // Generate a dot file for the dependency graph
@@ -43,8 +46,8 @@ The template file must be in YAML format following the image template schema.`,
 	}
 
 	// Add flags
-	buildCmd.Flags().IntVarP(&workers, "workers", "w", -1,
-		"Number of concurrent download workers")
+	buildCmd.Flags().IntVarP(&workers, "workers", "w", defaultWorkers,
+		"Number of concurrent download workers (default from config)")
 	buildCmd.Flags().StringVarP(&cacheDir, "cache-dir", "d", "",
 		"Package cache directory")
 	buildCmd.Flags().StringVar(&workDir, "work-dir", "",

--- a/cmd/image-composer-tool/build.go
+++ b/cmd/image-composer-tool/build.go
@@ -47,7 +47,7 @@ The template file must be in YAML format following the image template schema.`,
 
 	// Add flags
 	buildCmd.Flags().IntVarP(&workers, "workers", "w", defaultWorkers,
-		"Number of concurrent download workers (default from config)")
+		"Number of concurrent download workers, overrides config file value")
 	buildCmd.Flags().StringVarP(&cacheDir, "cache-dir", "d", "",
 		"Package cache directory")
 	buildCmd.Flags().StringVar(&workDir, "work-dir", "",

--- a/cmd/image-composer-tool/build_test.go
+++ b/cmd/image-composer-tool/build_test.go
@@ -544,7 +544,10 @@ func TestBuildCommand_FlagParsing(t *testing.T) {
 				if err := cmd.ParseFlags([]string{"--workers", "8"}); err != nil {
 					t.Fatalf("failed to parse flags: %v", err)
 				}
-				val, _ := cmd.Flags().GetInt("workers")
+				val, err := cmd.Flags().GetInt("workers")
+				if err != nil {
+					t.Fatalf("failed to get workers flag: %v", err)
+				}
 				if val != 8 {
 					t.Errorf("expected workers=8, got %d", val)
 				}

--- a/cmd/image-composer-tool/build_test.go
+++ b/cmd/image-composer-tool/build_test.go
@@ -17,7 +17,7 @@ import (
 
 // resetBuildFlags resets all build command flags to their default values
 func resetBuildFlags() {
-	workers = -1
+	workers = defaultWorkers
 	cacheDir = ""
 	workDir = ""
 }
@@ -512,8 +512,8 @@ func TestBuildCommand_Integration(t *testing.T) {
 func TestBuildFlags_DefaultValues(t *testing.T) {
 	resetBuildFlags()
 
-	if workers != -1 {
-		t.Errorf("workers should default to -1, got %d", workers)
+	if workers != defaultWorkers {
+		t.Errorf("workers should default to %d, got %d", defaultWorkers, workers)
 	}
 	if cacheDir != "" {
 		t.Errorf("cacheDir should default to empty, got %q", cacheDir)
@@ -544,12 +544,9 @@ func TestBuildCommand_FlagParsing(t *testing.T) {
 				if err := cmd.ParseFlags([]string{"--workers", "8"}); err != nil {
 					t.Fatalf("failed to parse flags: %v", err)
 				}
-				if workers != -1 {
-					// Flag value is set when the flag is parsed
-					val, _ := cmd.Flags().GetInt("workers")
-					if val != 8 {
-						t.Errorf("expected workers=8, got %d", val)
-					}
+				val, _ := cmd.Flags().GetInt("workers")
+				if val != 8 {
+					t.Errorf("expected workers=8, got %d", val)
 				}
 			},
 		},


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->

The `--workers` flag displayed `(default -1)` in `--help` output. The `-1` was an internal sentinel value meaning "use the config file value" (which defaults to 8), but this was confusing for users who had no context about the sentinel.

This PR replaces the `-1` sentinel with the effective default sourced from `config.DefaultGlobalConfig().Workers`, so `--help` now shows `(default 8)`.

**Before:**
```
  -w, --workers int   Number of concurrent download workers (default -1)
```

**After:**
```
  -w, --workers int   Number of concurrent download workers, overrides config file value (default 8)
```

The `cmd.Flags().Changed()` guard in `executeBuild` ensures the config override logic still works correctly - cobra only reports `Changed` when the user explicitly passes the flag, regardless of the default value.

No documentation update needed - this is a help-text-only change.

#### Any Newly Introduced Dependencies

None.

#### How Has This Been Tested? <!-- REQUIRED -->

- `go build ./cmd/... ./internal/...` - compiles cleanly
- `go test ./cmd/image-composer-tool/...` - all tests pass
- Updated `TestBuildFlags_DefaultValues` to assert new default
- Updated `TestBuildCommand_FlagParsing/WorkersFlag` to match simplified logic
- Verified `--help` output shows `(default 8)` instead of `(default -1)`