### PR TITLE
fix(imagedisc): honor requireEmpty with nested lsblk partition trees

### DIFF
--- a/internal/image/imagedisc/imagedisc.go
+++ b/internal/image/imagedisc/imagedisc.go
@@ -422,14 +422,67 @@ func DiskGetDevInfo(diskPath string) (map[string]interface{}, error) {
 	}
 	if blockDevices, ok := partitionsInfo["blockdevices"].([]interface{}); ok {
 		for _, device := range blockDevices {
-			dev := device.(map[string]interface{})
-			if dev["path"] == diskPath {
-				return dev, nil
+			dev, ok := device.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if found := findBlockDeviceByPath(dev, diskPath); found != nil {
+				return found, nil
 			}
 		}
 	}
 	log.Errorf("Device info not found for disk %s", diskPath)
 	return nil, errors.New("device not found")
+}
+
+func findBlockDeviceByPath(device map[string]interface{}, diskPath string) map[string]interface{} {
+	if device == nil {
+		return nil
+	}
+
+	if path, ok := device["path"].(string); ok && path == diskPath {
+		return device
+	}
+
+	children, ok := device["children"].([]interface{})
+	if !ok {
+		return nil
+	}
+
+	for _, child := range children {
+		childMap, ok := child.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if found := findBlockDeviceByPath(childMap, diskPath); found != nil {
+			return found
+		}
+	}
+
+	return nil
+}
+
+func collectPartitionDevices(device map[string]interface{}, partitions *[]map[string]interface{}) {
+	if device == nil || partitions == nil {
+		return
+	}
+
+	if devType, ok := device["type"].(string); ok && devType == "part" {
+		*partitions = append(*partitions, device)
+	}
+
+	children, ok := device["children"].([]interface{})
+	if !ok {
+		return
+	}
+
+	for _, child := range children {
+		childMap, ok := child.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		collectPartitionDevices(childMap, partitions)
+	}
 }
 
 func DiskGetPartitionsInfo(diskPath string) ([]map[string]interface{}, error) {
@@ -447,10 +500,11 @@ func DiskGetPartitionsInfo(diskPath string) ([]map[string]interface{}, error) {
 	var partitions []map[string]interface{}
 	if blockDevices, ok := partitionsInfo["blockdevices"].([]interface{}); ok {
 		for _, device := range blockDevices {
-			dev := device.(map[string]interface{})
-			if dev["type"] == "part" {
-				partitions = append(partitions, dev)
+			dev, ok := device.(map[string]interface{})
+			if !ok {
+				continue
 			}
+			collectPartitionDevices(dev, &partitions)
 		}
 	}
 	return partitions, nil

--- a/internal/image/imagedisc/imagedisc_test.go
+++ b/internal/image/imagedisc/imagedisc_test.go
@@ -435,6 +435,15 @@ func TestDiskGetPartitionsInfo(t *testing.T) {
 			expectedLen: 0,
 		},
 		{
+			name:     "nested_children_partitions",
+			diskPath: "/dev/sdb",
+			mockCommands: []shell.MockCommand{
+				{Pattern: "lsblk /dev/sdb", Output: `{"blockdevices":[{"name":"sdb","path":"/dev/sdb","type":"disk","children":[{"name":"sdb1","path":"/dev/sdb1","type":"part"},{"name":"sdb2","path":"/dev/sdb2","type":"part"}]}]}`, Error: nil},
+			},
+			expectError: false,
+			expectedLen: 2,
+		},
+		{
 			name:     "command_failure",
 			diskPath: "/dev/sda",
 			mockCommands: []shell.MockCommand{
@@ -1448,6 +1457,22 @@ func TestResolveInstallDiskPath(t *testing.T) {
 			},
 			lsblkOutput: `{"blockdevices":[{"name":"sdb","size":21474836480,"model":"Disk B","serial":"B","tran":"sata","type":"disk","rm":0,"rota":1},{"name":"sda","size":21474836480,"model":"Disk A","serial":"A","tran":"sata","type":"disk","rm":0,"rota":1}]}`,
 			expectPath:  "/dev/sda",
+		},
+		{
+			name: "largest_with_require_empty_true_selects_smaller_empty_usb",
+			diskConfig: config.DiskConfig{
+				SelectionPolicy: config.DiskSelectionPolicy{
+					Strategy:          "largest",
+					ExcludeRemovable:  boolPtr(false),
+					RequireEmpty:      boolPtr(true),
+				},
+			},
+			lsblkOutput: `{"blockdevices":[{"name":"sdb","size":68719476736,"model":"Large USB","serial":"B","tran":"usb","type":"disk","rm":1,"rota":0},{"name":"sda","size":32212254720,"model":"Small USB","serial":"A","tran":"usb","type":"disk","rm":1,"rota":0}]}`,
+			extraCommands: []shell.MockCommand{
+				{Pattern: "lsblk /dev/sdb --json --list --output", Output: `{"blockdevices":[{"name":"sdb","path":"/dev/sdb","type":"disk","children":[{"name":"sdb1","path":"/dev/sdb1","type":"part"}]}]}`, Error: nil},
+				{Pattern: "lsblk /dev/sda --json --list --output", Output: `{"blockdevices":[{"name":"sda","path":"/dev/sda","type":"disk"}]}`, Error: nil},
+			},
+			expectPath: "/dev/sda",
 		},
 		{
 			name: "exclude_removable_false_with_require_empty_true_can_select_external_empty",

--- a/internal/image/imagedisc/imagedisc_test.go
+++ b/internal/image/imagedisc/imagedisc_test.go
@@ -1462,9 +1462,9 @@ func TestResolveInstallDiskPath(t *testing.T) {
 			name: "largest_with_require_empty_true_selects_smaller_empty_usb",
 			diskConfig: config.DiskConfig{
 				SelectionPolicy: config.DiskSelectionPolicy{
-					Strategy:          "largest",
-					ExcludeRemovable:  boolPtr(false),
-					RequireEmpty:      boolPtr(true),
+					Strategy:         "largest",
+					ExcludeRemovable: boolPtr(false),
+					RequireEmpty:     boolPtr(true),
 				},
 			},
 			lsblkOutput: `{"blockdevices":[{"name":"sdb","size":68719476736,"model":"Large USB","serial":"B","tran":"usb","type":"disk","rm":1,"rota":0},{"name":"sda","size":32212254720,"model":"Small USB","serial":"A","tran":"usb","type":"disk","rm":1,"rota":0}]}`,


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->
`requireEmpty: true` could be bypassed when `lsblk` returned partitions as nested `children`, causing `largest` selection to choose a larger non-empty USB disk.

- make `DiskGetPartitionsInfo` recursively collect partition nodes
- make `DiskGetDevInfo` recursively locate devices by path
- add regression test for nested `children` partition parsing
- add regression test for two-USB case: `strategy=largest`, `excludeRemovable=false`, `requireEmpty=true` now correctly selects the smaller empty USB over a larger partitioned USB

Validated with:
- `go test ./internal/image/imagedisc -run 'TestDiskGetPartitionsInfo|TestResolveInstallDiskPath'`
- `go test ./internal/image/imagedisc`
<!-- Fixes # (issue) -->

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->
tested in PTL with below use case:

(usb)sda - empty
(usb)sdb - iso installer
nvme - have image

result: sda selected

-----------------------------
(usb)sda - have image
(usb)sdb - empty
nvme - iso installer

result: sdb selected

----------------------------
(usb)sda -iso installer
(usb)sdb- have image
nvme- empty

result: nvme selected