### PR TITLE
fix SBOM inaccurate in ISO

### DIFF
--- a/cmd/live-installer/install.go
+++ b/cmd/live-installer/install.go
@@ -418,6 +418,16 @@ func createNewBootEntry(template *config.ImageTemplate, diskPathIdMap map[string
 	return nil
 }
 
+func hydrateSBOMMetadataForInstaller(template *config.ImageTemplate) {
+	if template == nil {
+		return
+	}
+
+	if len(template.FullPkgListBom) == 0 && len(template.SBOMPackageMetadata) > 0 {
+		template.FullPkgListBom = template.SBOMPackageMetadata
+	}
+}
+
 func unattendedInstall(templateFile, localRepo string) error {
 	templateDir := filepath.Dir(templateFile)
 	configDir := filepath.Join(templateDir, "..", "..", "..", "..", "..")
@@ -430,6 +440,7 @@ func unattendedInstall(templateFile, localRepo string) error {
 	if err != nil {
 		return fmt.Errorf("failed to load template: %w", err)
 	}
+	hydrateSBOMMetadataForInstaller(template)
 	log.Infof("Loaded template: %s (type: %s)", template.Image.Name, template.Target.ImageType)
 
 	return install(template, configDir, localRepo)
@@ -447,6 +458,7 @@ func attendedInstall(templateFile, localRepo string) (installationQuit bool, err
 	if err != nil {
 		return false, fmt.Errorf("failed to load template: %w", err)
 	}
+	hydrateSBOMMetadataForInstaller(template)
 	log.Infof("Loaded template: %s (type: %s)", template.Image.Name, template.Target.ImageType)
 
 	attendedInstaller, err := attendedinstaller.New(template, configDir, localRepo, install)

--- a/cmd/live-installer/install_test.go
+++ b/cmd/live-installer/install_test.go
@@ -8,8 +8,52 @@ import (
 	"testing"
 
 	"github.com/open-edge-platform/image-composer-tool/internal/config"
+	"github.com/open-edge-platform/image-composer-tool/internal/ospackage"
 	"github.com/open-edge-platform/image-composer-tool/internal/utils/shell"
 )
+
+func TestHydrateSBOMMetadataForInstaller(t *testing.T) {
+	t.Run("copies_sbom_metadata_when_full_bom_is_empty", func(t *testing.T) {
+		template := &config.ImageTemplate{
+			SBOMPackageMetadata: []ospackage.PackageInfo{
+				{Name: "pkg-a", Type: "deb", Version: "1.0.0", URL: "https://example.test/pkg-a.deb"},
+			},
+		}
+
+		hydrateSBOMMetadataForInstaller(template)
+
+		if len(template.FullPkgListBom) != 1 {
+			t.Fatalf("expected FullPkgListBom to be hydrated with 1 package, got %d", len(template.FullPkgListBom))
+		}
+		if template.FullPkgListBom[0].Name != "pkg-a" {
+			t.Fatalf("expected hydrated package name pkg-a, got %s", template.FullPkgListBom[0].Name)
+		}
+	})
+
+	t.Run("does_not_override_existing_full_bom", func(t *testing.T) {
+		template := &config.ImageTemplate{
+			FullPkgListBom: []ospackage.PackageInfo{
+				{Name: "existing", Type: "deb", Version: "2.0.0"},
+			},
+			SBOMPackageMetadata: []ospackage.PackageInfo{
+				{Name: "fallback", Type: "deb", Version: "1.0.0"},
+			},
+		}
+
+		hydrateSBOMMetadataForInstaller(template)
+
+		if len(template.FullPkgListBom) != 1 {
+			t.Fatalf("expected existing FullPkgListBom length to remain 1, got %d", len(template.FullPkgListBom))
+		}
+		if template.FullPkgListBom[0].Name != "existing" {
+			t.Fatalf("expected existing package to be preserved, got %s", template.FullPkgListBom[0].Name)
+		}
+	})
+
+	t.Run("nil_template_is_noop", func(t *testing.T) {
+		hydrateSBOMMetadataForInstaller(nil)
+	})
+}
 
 func TestSuppressHostAptBackgroundTasks(t *testing.T) {
 	originalShell := shell.Default

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,6 +106,7 @@ type ImageTemplate struct {
 	KernelPkgList        []string                `yaml:"-"`
 	FullPkgList          []string                `yaml:"-"`
 	FullPkgListBom       []ospackage.PackageInfo `yaml:"-"`
+	SBOMPackageMetadata  []ospackage.PackageInfo `yaml:"sbomPackageMetadata,omitempty"`
 	DotFilePath          string                  `yaml:"-"`
 	DotSystemOnly        bool                    `yaml:"-"`
 	pureBuildStart       time.Time

--- a/internal/config/schema/os-image-template.schema.json
+++ b/internal/config/schema/os-image-template.schema.json
@@ -562,6 +562,11 @@
         "target": { "$ref": "#/$defs/Target" },
         "disk": { "$ref": "#/$defs/Disk" },
         "systemConfig": { "$ref": "#/$defs/SystemConfig" },
+        "sbomPackageMetadata": {
+          "type": "array",
+          "description": "Optional SBOM package metadata preserved for installer-time SBOM generation",
+          "items": { "type": "object", "additionalProperties": true }
+        },
         "packageRepositories": {
           "type": "array",
           "description": "Additional package repositories",
@@ -580,6 +585,11 @@
         "target": { "$ref": "#/$defs/Target" },
         "disk": { "$ref": "#/$defs/Disk" },
         "systemConfig": { "$ref": "#/$defs/SystemConfig" },
+        "sbomPackageMetadata": {
+          "type": "array",
+          "description": "Optional SBOM package metadata preserved for installer-time SBOM generation",
+          "items": { "type": "object", "additionalProperties": true }
+        },
         "packageRepositories": {
           "type": "array",
           "description": "Additional package repositories",

--- a/internal/image/imageos/imageos.go
+++ b/internal/image/imageos/imageos.go
@@ -2043,6 +2043,12 @@ func (imageOs *ImageOs) generateSBOM(installRoot string, template *config.ImageT
 
 	installRootPkgs := strings.Split(strings.TrimSpace(result), "\n")
 	downloadedPkgs := template.FullPkgListBom
+	if len(downloadedPkgs) == 0 {
+		// live-installer loads template-dump.yaml where FullPkgListBom is not serialized.
+		// Fallback to installed package metadata only in this case; RAW flow remains unchanged.
+		log.Warnf("SBOM metadata list is empty; falling back to installed package metadata")
+		downloadedPkgs = imageOs.installedPackageNamesAsSBOMMetadata(installRootPkgs, pkgType)
+	}
 
 	// Create a map of normalized package names from installed packages for faster lookup
 	installedPkgMap := make(map[string]bool)
@@ -2086,6 +2092,30 @@ func (imageOs *ImageOs) generateSBOM(installRoot string, template *config.ImageT
 	}
 
 	return result, nil
+}
+
+func (imageOs *ImageOs) installedPackageNamesAsSBOMMetadata(installedPkgs []string, pkgType string) []ospackage.PackageInfo {
+	pkgs := make([]ospackage.PackageInfo, 0, len(installedPkgs))
+	for _, pkg := range installedPkgs {
+		name := strings.TrimSpace(pkg)
+		if name == "" {
+			continue
+		}
+
+		if colonIndex := strings.Index(name, ":"); colonIndex != -1 {
+			name = name[:colonIndex]
+		}
+
+		pkgs = append(pkgs, ospackage.PackageInfo{
+			Name:    name,
+			Type:    pkgType,
+			URL:     "NOASSERTION",
+			License: "NOASSERTION",
+			Origin:  "NOASSERTION",
+		})
+	}
+
+	return pkgs
 }
 
 // isSymlink checks if a given path is a symbolic link

--- a/internal/image/isomaker/isomaker.go
+++ b/internal/image/isomaker/isomaker.go
@@ -298,6 +298,7 @@ func (isoMaker *IsoMaker) copyConfigFilesToIso(template *config.ImageTemplate, i
 		}
 	}
 	template.SystemConfig.AdditionalFiles = PathUpdatedList
+	template.SBOMPackageMetadata = template.FullPkgListBom
 
 	// Dump updated template to ISO
 	templateDumpFilePath := filepath.Join(isoMaker.ImageBuildDir, "template-dump.yaml")


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->
This PR aims to fix inaccurate/empty SBOM generation for ISO-based installs by persisting package metadata into template-dump.yaml and rehydrating it in the live-installer so SBOM generation can use the correct package metadata.

Changes:

Serialize downloaded package metadata into the ISO’s template-dump.yaml via a new sbomPackageMetadata template field.
Hydrate SBOM metadata in live-installer after loading the template, and add a fallback path in SBOM generation when metadata is missing.
Extend the template JSON schema and add a unit test for the installer hydration helper.

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->
Tested on QEMU
<img width="1183" height="773" alt="Screenshot 2026-06-10 155303" src="https://github.com/user-attachments/assets/4d84e1fd-5a77-4bc6-9d22-aefb740a5423" />
