### PR TITLE
Updated dlstreamer image template to fix missing gvadetect plugin issue

### DIFF
--- a/image-templates/azl3-x86_64-dlstreamer.yml
+++ b/image-templates/azl3-x86_64-dlstreamer.yml
@@ -96,10 +96,10 @@ systemConfig:
     - paho-mqtt-c
     - ffmpeg
     - gstreamer
+    - intel-dlstreamer-2026.0.0
     - opencv
     - util-linux-devel-2.40.2-3.emt3
-    - intel-dlstreamer-2025.2.0
-    - openvino-2025.3.0
+    - openvino-2026.0.0
     - linux-firmware-i915
 
   kernel:

--- a/image-templates/emt3-x86_64-dlstreamer.yml
+++ b/image-templates/emt3-x86_64-dlstreamer.yml
@@ -154,10 +154,9 @@ systemConfig:
     - nano
     - paho-mqtt-c
     - ffmpeg
-    - gstreamer
     - opencv
-    - intel-dlstreamer-2025.2.0
-    - openvino-2025.3.0
+    - intel-dlstreamer-2026.0.0
+    - openvino-2026.0.0
 
   # Kernel Configuration
   kernel:

--- a/image-templates/rcd10-x86_64-dlstreamer.yml
+++ b/image-templates/rcd10-x86_64-dlstreamer.yml
@@ -84,7 +84,11 @@ systemConfig:
     - paho-mqtt-c
     - ffmpeg
     - opencv
-    - intel-dlstreamer-2026.0.0
-    - openvino-2026.0.0
+    - intel-dlstreamer-2025.2.0
+    - openvino-2025.3.0
     - linux-firmware-i915
     # - tdnf
+
+  configurations:
+    # Edit source file path for dlstreamer opencv plugin
+    - cmd: sed -i 's|export LD_LIBRARY_PATH="|export LD_LIBRARY_PATH="/usr/local/lib64:|' /opt/intel/dlstreamer/setupvars.sh

--- a/image-templates/rcd10-x86_64-dlstreamer.yml
+++ b/image-templates/rcd10-x86_64-dlstreamer.yml
@@ -83,9 +83,8 @@ systemConfig:
     - nano
     - paho-mqtt-c
     - ffmpeg
-    - gstreamer
     - opencv
-    - intel-dlstreamer-2025.2.0
-    - openvino-2025.3.0
+    - intel-dlstreamer-2026.0.0
+    - openvino-2026.0.0
     - linux-firmware-i915
     # - tdnf


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [ ] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->
missing gvadetect plugin issue occurred during dlstreamer test, found out it was due to older version of dlstreamer having glib 2.80 dependencies, updated the image template to newer dlstreamer (2026.0.0) which doesn't have glib 2.80 dependencies. 
<!-- Fixes # (issue) -->
<img width="1287" height="1448" alt="Screenshot from 2026-06-09 15-53-53" src="https://github.com/user-attachments/assets/63139995-eaa4-4cf2-b372-0f2e633c526b" />

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->
Built and tested both emt and azl dlstreamer images, both have gvadetect working
<img width="1420" height="886" alt="image" src="https://github.com/user-attachments/assets/2a2b1cb1-2015-449e-84a6-f299ff58f75f" />
