### PR TITLE
fix AZL and EMT iso not able to boot

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -238,6 +239,8 @@ type PartitionInfo struct {
 }
 
 var log = logger.Logger()
+
+var invalidBlockScalarHeaderPattern = regexp.MustCompile(`(: \|)\d+([+-]?)\n`)
 
 // LoadTemplate loads an ImageTemplate from the specified YAML template path
 func LoadTemplate(path string, validateFull bool) (*ImageTemplate, error) {
@@ -697,6 +700,17 @@ func (t *ImageTemplate) SaveUpdatedConfigFile(path string) error {
 		return fmt.Errorf("error marshaling template to YAML: %w", err)
 	}
 
+	if err := validateYAMLBytes(data); err != nil {
+		log.Warnf("Generated YAML is not parseable, applying block scalar header fix: %v", err)
+
+		data = fixInvalidBlockScalarHeader(data)
+
+		if validateErr := validateYAMLBytes(data); validateErr != nil {
+			log.Errorf("Generated YAML remains invalid after block scalar header fix: %v", validateErr)
+			return fmt.Errorf("generated YAML is invalid after block scalar header fix: %w", validateErr)
+		}
+	}
+
 	// Write file safely with symlink protection
 	if err := security.SafeWriteFile(path, data, 0644, security.RejectSymlinks); err != nil {
 		log.Errorf("Failed to write image template to %s: %v", path, err)
@@ -705,6 +719,18 @@ func (t *ImageTemplate) SaveUpdatedConfigFile(path string) error {
 
 	log.Infof("Saved image template to %s", path)
 	return nil
+}
+
+func validateYAMLBytes(data []byte) error {
+	var parsed any
+
+	return yaml.Unmarshal(data, &parsed)
+}
+
+func fixInvalidBlockScalarHeader(data []byte) []byte {
+	// Work around yaml.v3 emitting invalid explicit indent headers such as "|4-".
+	// Keep the payload and chomping mode untouched, and drop only the indent indicator.
+	return invalidBlockScalarHeaderPattern.ReplaceAll(data, []byte("$1$2\n"))
 }
 
 // GetImmutability returns the immutability configuration from systemConfig

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/open-edge-platform/image-composer-tool/internal/config/validate"
+	"github.com/open-edge-platform/image-composer-tool/internal/ospackage"
 	"gopkg.in/yaml.v3"
 )
 
@@ -1481,6 +1482,118 @@ func TestSaveUpdatedConfigFile(t *testing.T) {
 
 	if strings.Contains(string(data), "index: null") {
 		t.Fatalf("dumped config unexpectedly contains 'index: null'\n%s", string(data))
+	}
+}
+
+func TestSaveUpdatedConfigFileFixesInvalidBlockScalarHeader(t *testing.T) {
+	t.Parallel()
+
+	template := &ImageTemplate{
+		Image: ImageInfo{
+			Name:    "test-save-sbom",
+			Version: "1.0.0",
+		},
+		SBOMPackageMetadata: []ospackage.PackageInfo{
+			{
+				Name:        "newt-0.52.23-1.azl3.x86_64.rpm",
+				Type:        "rpm",
+				Description: "\nline1\nline2",
+				Origin:      "Microsoft",
+				License:     "GPLv2",
+				Version:     "0:0.52.23-1.azl3",
+				Arch:        "x86_64",
+				URL:         "https://example.invalid/newt.rpm",
+			},
+		},
+	}
+
+	outPath := filepath.Join(t.TempDir(), "test-sbom.yml")
+
+	if err := template.SaveUpdatedConfigFile(outPath); err != nil {
+		t.Fatalf("SaveUpdatedConfigFile returned unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("failed to read dumped config: %v", err)
+	}
+
+	var parsed any
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("dumped config is not valid YAML: %v\n%s", err, string(data))
+	}
+
+	var roundTrip ImageTemplate
+	if err := yaml.Unmarshal(data, &roundTrip); err != nil {
+		t.Fatalf("failed to unmarshal dumped config into ImageTemplate: %v", err)
+	}
+
+	if len(roundTrip.SBOMPackageMetadata) != 1 {
+		t.Fatalf("expected 1 sbom package metadata entry, got %d", len(roundTrip.SBOMPackageMetadata))
+	}
+
+	if roundTrip.SBOMPackageMetadata[0].Description != "line1\nline2" {
+		t.Fatalf(
+			"expected sanitized description %q, got %q",
+			"line1\\nline2",
+			roundTrip.SBOMPackageMetadata[0].Description,
+		)
+	}
+
+	if strings.Contains(string(data), "description: |4-") {
+		t.Fatalf("dumped config still contains invalid block scalar header |4-\n%s", string(data))
+	}
+
+	if roundTrip.SBOMPackageMetadata[0].Origin != "Microsoft" ||
+		roundTrip.SBOMPackageMetadata[0].License != "GPLv2" ||
+		roundTrip.SBOMPackageMetadata[0].Version != "0:0.52.23-1.azl3" ||
+		roundTrip.SBOMPackageMetadata[0].Arch != "x86_64" ||
+		roundTrip.SBOMPackageMetadata[0].URL != "https://example.invalid/newt.rpm" {
+		t.Fatalf("unexpected SBOM metadata mutation after save: %+v", roundTrip.SBOMPackageMetadata[0])
+	}
+}
+
+func TestFixInvalidBlockScalarHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "removes single digit indent and preserves strip chomping",
+			input: "description: |4-\n    line1\n",
+			want:  "description: |-\n    line1\n",
+		},
+		{
+			name:  "removes multi digit indent and preserves keep chomping",
+			input: "description: |12+\n            line1\n",
+			want:  "description: |+\n            line1\n",
+		},
+		{
+			name:  "removes indent without chomping indicator",
+			input: "description: |2\n  line1\n",
+			want:  "description: |\n  line1\n",
+		},
+		{
+			name:  "leaves inferred indent header untouched",
+			input: "description: |-\n  line1\n",
+			want:  "description: |-\n  line1\n",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := string(fixInvalidBlockScalarHeader([]byte(tt.input)))
+
+			if got != tt.want {
+				t.Fatalf("fixInvalidBlockScalarHeader() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#### Merge Checklist  <!-- REQUIRED -->

**All** boxes should be checked before merging the PR

- [x] The changes in the PR have been built and tested
- [x] Documentation has been updated to reflect the changes (or no doc update needed)
- [x] Ready to merge

#### Description <!-- REQUIRED -->
<!-- Please include a summary of the changes and the related issue. List
any dependencies that are required for this change. -->

<!-- Fixes # (issue) -->
This PR aims to ensure YAML emitted by ImageTemplate.SaveUpdatedConfigFile is parseable, specifically addressing invalid block-scalar headers observed when dumping SBOM package metadata (used by ISO/template dumps and the live installer).

Changes:

Adds a YAML round-trip parse check after yaml.Marshal, with a fallback “block scalar header” repair pass before writing the file.
Introduces a regex-based fix-up function for invalid block-scalar headers.
Adds unit tests covering the save-path behavior and the header fix-up helper.

#### Any Newly Introduced Dependencies
<!-- Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information and how they are used in the project. -->

#### How Has This Been Tested? <!-- REQUIRED -->
<!-- Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration. -->